### PR TITLE
"Advanced Options" Setting For Map Gen: Specific Amounts of Different Types of Neutral Zones and Min Neutral Distance Between Players, PNGs when generating maps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+# AGENTS.md
+
+Guidance for agents working on this repository.
+
+## Project Overview
+
+This is a C# WPF desktop app for generating `.rmg.json` random map template files for Heroes of Might and Magic: Olden Era.
+
+The main solution is:
+
+```powershell
+dotnet build "Olden Era - Template Editor.slnx"
+```
+
+The app project is:
+
+```text
+Olden Era - Template Editor/Olden Era - Template Editor.csproj
+```
+
+The unit test project is:
+
+```text
+Olden Era - Template Editor.Tests/Olden Era - Template Editor.Tests.csproj
+```
+
+The test project uses xUnit and targets the generator/model layer without requiring WPF UI automation.
+
+Example templates are stored in:
+
+```text
+Olden Era - Template Editor/ExampleTemplates
+```
+
+Use those examples as the primary local reference for the `.rmg.json` shape and expected naming style.
+
+## Discovering Olden Era `.rmg.json` Files
+
+Olden Era map templates are almost always located under the game's install directory:
+
+```text
+[Steam Game Install Location]\HeroesOldenEra_Data\StreamingAssets\map_templates
+```
+
+The standard Steam install location is usually:
+
+```text
+C:\Program Files (x86)\Steam\steamapps\common\Heroes of Might and Magic Olden Era\HeroesOldenEra_Data\StreamingAssets\map_templates
+```
+
+Do not assume that path always exists. Users may have installed Steam or the game on another drive, especially on systems with multiple disks or custom Steam libraries.
+
+Useful discovery checks:
+
+```powershell
+$defaultTemplates = "${env:ProgramFiles(x86)}\Steam\steamapps\common\Heroes of Might and Magic Olden Era\HeroesOldenEra_Data\StreamingAssets\map_templates"
+Test-Path $defaultTemplates
+Get-ChildItem -Path $defaultTemplates -Filter "*.rmg.json" -ErrorAction SilentlyContinue
+```
+
+If the default path is missing, inspect Steam library locations. The primary Steam library file is usually:
+
+```text
+C:\Program Files (x86)\Steam\steamapps\libraryfolders.vdf
+```
+
+Additional libraries typically contain:
+
+```text
+[Steam Library]\steamapps\common\Heroes of Might and Magic Olden Era\HeroesOldenEra_Data\StreamingAssets\map_templates
+```
+
+A quick targeted check for common Steam library roots:
+
+```powershell
+Get-PSDrive -PSProvider FileSystem | ForEach-Object {
+    $candidate = Join-Path $_.Root "SteamLibrary\steamapps\common\Heroes of Might and Magic Olden Era\HeroesOldenEra_Data\StreamingAssets\map_templates"
+    if (Test-Path $candidate) {
+        Get-Item $candidate
+    }
+}
+```
+
+Avoid broad recursive searches across entire drives unless the user asks for that; they can be slow.
+
+## Commands And Testing
+
+This is a C# solution. Before handing off changes, build the solution:
+
+```powershell
+dotnet build "Olden Era - Template Editor.slnx"
+```
+
+Unit tests are part of the normal development process. When changing behavior, always add or update focused unit tests that cover the change, then ensure the full unit test suite passes before handing off:
+
+```powershell
+dotnet test "Olden Era - Template Editor.slnx"
+```
+
+If `dotnet` is not on PATH in the current shell, use the standard SDK path explicitly:
+
+```powershell
+& "C:\Program Files\dotnet\dotnet.exe" test "Olden Era - Template Editor.slnx"
+```
+
+For changes to generator logic, prefer focused unit tests around the model/service behavior rather than only testing through the UI.
+
+## Visual Testing
+
+For UI changes, build and run the app, then visually check the affected workflow. The app should open cleanly, controls should be readable, and the expected action should work without layout breakage.
+
+Typical local run command:
+
+```powershell
+dotnet run --project "Olden Era - Template Editor/Olden Era - Template Editor.csproj"
+```
+
+When possible, open the solution in Visual Studio as part of manual verification:
+
+```powershell
+Start-Process "Olden Era - Template Editor.slnx"
+```
+
+At minimum, verify that the configured options can create a `.rmg.json` file. Generated template validation currently stops there: do not claim that generated templates are guaranteed to generate a playable map in game. In-game validation must be left to users until the project has a reliable automated or documented game-level validation workflow.
+
+## Development Notes
+
+- Keep changes scoped to the app's current C# and WPF patterns.
+- Add or update unit tests for every behavior change, and do not treat the work as complete until those tests pass.
+- Prefer structured JSON serialization/deserialization over manual string editing for template files.
+- Treat the bundled example templates as fixtures and references; do not overwrite them during ad hoc testing.
+- When saving generated files during testing, use a temporary location unless the user explicitly wants files written into their game install.
+- Be careful with paths containing spaces, especially the solution name, project directory, Steam install path, and template filenames.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,3 +131,4 @@ At minimum, verify that the configured options can create a `.rmg.json` file. Ge
 - Treat the bundled example templates as fixtures and references; do not overwrite them during ad hoc testing.
 - When saving generated files during testing, use a temporary location unless the user explicitly wants files written into their game install.
 - Be careful with paths containing spaces, especially the solution name, project directory, Steam install path, and template filenames.
+- Assume other individuals or agents may be working elsewhere in the repository at the same time. Ignore and preserve changes you did not specifically make; do not revert, overwrite, or include them in your work unless the user explicitly asks.

--- a/Olden Era - Template Editor.Tests/Olden Era - Template Editor.Tests.csproj
+++ b/Olden Era - Template Editor.Tests/Olden Era - Template Editor.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Olden_Era___Template_Editor.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Olden Era - Template Editor\Olden Era - Template Editor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
+++ b/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
@@ -2,6 +2,9 @@ using System.Text.Json;
 using Olden_Era___Template_Editor.Models;
 using Olden_Era___Template_Editor.Services;
 using OldenEraTemplateEditor.Models;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 
 namespace Olden_Era___Template_Editor.Tests;
 
@@ -30,13 +33,36 @@ public class TemplateGeneratorTests
         Assert.Equal(settings.MapSize, template.SizeX);
         Assert.Equal(settings.MapSize, template.SizeZ);
         Assert.Equal(settings.VictoryCondition, template.DisplayWinCondition);
-        Assert.Equal("custom_generated_template", template.Description);
+        Assert.Equal("Generated with Olden Era Template Generator: Classic mode, 2 players, 200x200 map, Ring layout, no neutral zones, 1 castle per player zone.", template.Description);
         Assert.NotNull(template.GameRules);
         Assert.Equal(settings.HeroCountMin, template.GameRules.HeroCountMin);
         Assert.Equal(settings.HeroCountMax, template.GameRules.HeroCountMax);
         Assert.Equal(settings.HeroCountIncrement, template.GameRules.HeroCountIncrement);
         Assert.NotEmpty(template.ZoneLayouts ?? []);
         Assert.NotEmpty(template.ContentCountLimits ?? []);
+    }
+
+    [Fact]
+    public void Generate_WritesBasicTemplateDescription()
+    {
+        var settings = new GeneratorSettings
+        {
+            GameMode = "SingleHero",
+            PlayerCount = 4,
+            NeutralZoneCount = 2,
+            MapSize = 192,
+            PlayerZoneCastles = 2,
+            NeutralZoneCastles = 0,
+            Topology = MapTopology.Chain,
+            NoDirectPlayerConnections = true,
+            RandomPortals = true,
+            SpawnRemoteFootholds = false,
+            GenerateRoads = false
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.Equal("Generated with Olden Era Template Generator: SingleHero mode, 4 players, 192x192 map, Chain layout, 2 neutral zones, 2 castles per player zone, no castles per neutral zone, options: isolated player starts, random portals, no remote footholds, roads disabled.", template.Description);
     }
 
     [Fact]
@@ -69,6 +95,65 @@ public class TemplateGeneratorTests
             zone => Assert.Equal(2, zone.MainObjects?.Count));
         Assert.All(zones.Where(zone => zone.Name.StartsWith("Neutral-", StringComparison.Ordinal)),
             zone => Assert.Single(zone.MainObjects ?? []));
+    }
+
+    [Fact]
+    public void Generate_SharedWebReferencesSpokeConnectionsFromBothEndpointZones()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 4,
+            NeutralZoneCount = 3,
+            NeutralZoneCastles = 1,
+            Topology = MapTopology.SharedWeb,
+            RandomPortals = false
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        var zones = RequiredZones(variant).ToDictionary(zone => zone.Name, StringComparer.Ordinal);
+        var webConnections = RequiredConnections(variant)
+            .Where(connection => connection.Name?.StartsWith("Web-", StringComparison.Ordinal) == true)
+            .ToList();
+
+        Assert.NotEmpty(webConnections);
+        Assert.All(webConnections, connection =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(connection.Name));
+            string name = connection.Name!;
+            Assert.Contains(name, RoadConnectionNames(zones[connection.From]));
+            Assert.Contains(name, RoadConnectionNames(zones[connection.To]));
+        });
+    }
+
+    [Fact]
+    public void Generate_SharedWebCastlelessNeutralZonesUseConnectionRoads()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            NeutralZoneCount = 0,
+            NeutralZoneCastles = 0,
+            Topology = MapTopology.SharedWeb,
+            RandomPortals = false
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        Zone neutralZone = Assert.Single(RequiredZones(variant),
+            zone => zone.Name.StartsWith("Neutral-", StringComparison.Ordinal));
+        var webConnectionNames = RequiredConnections(variant)
+            .Where(connection => connection.Name?.StartsWith("Web-", StringComparison.Ordinal) == true)
+            .Select(connection => connection.Name!)
+            .ToList();
+
+        Assert.Empty(neutralZone.MainObjects ?? []);
+        Assert.NotEmpty(neutralZone.Roads ?? []);
+        Assert.All(neutralZone.Roads ?? [], road =>
+        {
+            Assert.Equal("Connection", road.From?.Type);
+            Assert.Equal("Connection", road.To?.Type);
+        });
+        Assert.Equal(2, webConnectionNames.Count);
+        Assert.All(webConnectionNames, name => Assert.Contains(name, RoadConnectionNames(neutralZone)));
     }
 
     [Fact]
@@ -309,6 +394,72 @@ public class TemplateGeneratorTests
     }
 
     [Fact]
+    public void Generate_BalancedRingEvenlySpacesPlayersAndNeutralQuality()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 4,
+            AdvancedMode = true,
+            NeutralZoneCastles = 1,
+            NeutralLowNoCastleCount = 4,
+            NeutralHighCastleCount = 4,
+            Topology = MapTopology.Default,
+            ExperimentalBalancedZonePlacement = true
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        var zones = RequiredZones(variant);
+        var sequence = zones.Select(zone => zone.Name).ToList();
+        var zonesByName = zones.ToDictionary(zone => zone.Name, StringComparer.Ordinal);
+        var gaps = RingNeutralGapsBetweenPlayers(sequence);
+
+        Assert.Equal(4, gaps.Count);
+        Assert.All(gaps, gap =>
+        {
+            Assert.Equal(2, gap.Count);
+            Assert.Single(gap, zoneName => zonesByName[zoneName].Layout == "zone_layout_center");
+            Assert.Single(gap, zoneName => zonesByName[zoneName].Layout == "zone_layout_sides");
+        });
+
+        var playerDistanceTotals = RingPlayerDistanceTotals(sequence);
+        Assert.Single(playerDistanceTotals.Values.Distinct());
+    }
+
+    [Fact]
+    public void Generate_BalancedSharedWebGivesEachPlayerMixedNeutralQuality()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 4,
+            AdvancedMode = true,
+            NeutralZoneCastles = 1,
+            NeutralLowNoCastleCount = 4,
+            NeutralHighCastleCount = 4,
+            Topology = MapTopology.SharedWeb,
+            ExperimentalBalancedZonePlacement = true
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        var zonesByName = RequiredZones(variant).ToDictionary(zone => zone.Name, StringComparer.Ordinal);
+        var webConnectionsByPlayer = RequiredConnections(variant)
+            .Where(connection => connection.Name?.StartsWith("Web-", StringComparison.Ordinal) == true)
+            .GroupBy(connection => connection.From, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(4, webConnectionsByPlayer.Count);
+        Assert.All(webConnectionsByPlayer, group =>
+        {
+            var connectedLayouts = group
+                .Select(connection => zonesByName[connection.To].Layout)
+                .ToList();
+
+            Assert.Equal(2, connectedLayouts.Count);
+            Assert.Contains("zone_layout_center", connectedLayouts);
+            Assert.Contains("zone_layout_sides", connectedLayouts);
+        });
+    }
+
+    [Fact]
     public void Generate_AdvancedModeCanCreateThirtyTwoTotalZones()
     {
         var settings = new GeneratorSettings
@@ -520,6 +671,50 @@ public class TemplateGeneratorTests
     }
 
     [Fact]
+    public void TemplatePreviewPngWriter_Save_EncodesNeutralQualityAndCastleCounts()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"olden-preview-test-{Guid.NewGuid():N}");
+        string previewPath = Path.Combine(directory, "Preview.png");
+        var template = new RmgTemplate
+        {
+            Name = "Preview Test",
+            Variants =
+            [
+                new Variant
+                {
+                    Zones =
+                    [
+                        new Zone { Name = "Neutral-A", Layout = "zone_layout_sides", MainObjects = [] },
+                        new Zone { Name = "Neutral-B", Layout = "zone_layout_treasure_zone", MainObjects = Cities(3) },
+                        new Zone { Name = "Neutral-C", Layout = "zone_layout_center", MainObjects = Cities(2) }
+                    ],
+                    Connections = []
+                }
+            ]
+        };
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+            RunOnStaThread(() => TemplatePreviewPngWriter.Save(template, previewPath));
+            BitmapSource bitmap = LoadBitmap(previewPath);
+
+            AssertColorNear(Color.FromRgb(28, 22, 16), PixelAt(bitmap, 256, 72));
+            AssertColorNear(Color.FromRgb(173, 176, 176), PixelAt(bitmap, 412, 342));
+            AssertColorNear(Color.FromRgb(214, 166, 61), PixelAt(bitmap, 100, 342));
+
+            int lowLabelPixels = CountBrightPixels(bitmap, new Int32Rect(244, 78, 24, 20));
+            int castleLabelPixels = CountBrightPixels(bitmap, new Int32Rect(400, 348, 24, 20));
+            Assert.True(castleLabelPixels > lowLabelPixels + 10);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void SettingsFile_LegacyContentDensitySeedsSplitDensitySettings()
     {
         const string json = """
@@ -579,6 +774,79 @@ public class TemplateGeneratorTests
         });
     }
 
+    private static List<MainObject> Cities(int count) =>
+        Enumerable.Range(0, count).Select(_ => new MainObject { Type = "City" }).ToList();
+
+    private static void RunOnStaThread(Action action)
+    {
+        Exception? thrown = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                thrown = ex;
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        if (thrown is not null)
+            throw new InvalidOperationException("The STA action failed.", thrown);
+    }
+
+    private static BitmapSource LoadBitmap(string path)
+    {
+        using var stream = File.OpenRead(path);
+        BitmapSource source = BitmapDecoder
+            .Create(stream, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.OnLoad)
+            .Frames[0];
+
+        var converted = new FormatConvertedBitmap(source, PixelFormats.Bgra32, null, 0);
+        converted.Freeze();
+        return converted;
+    }
+
+    private static Color PixelAt(BitmapSource bitmap, int x, int y)
+    {
+        byte[] pixels = new byte[4];
+        bitmap.CopyPixels(new Int32Rect(x, y, 1, 1), pixels, 4, 0);
+        return Color.FromRgb(pixels[2], pixels[1], pixels[0]);
+    }
+
+    private static int CountBrightPixels(BitmapSource bitmap, Int32Rect rect)
+    {
+        int stride = rect.Width * 4;
+        byte[] pixels = new byte[stride * rect.Height];
+        bitmap.CopyPixels(rect, pixels, stride, 0);
+
+        int count = 0;
+        for (int i = 0; i < pixels.Length; i += 4)
+        {
+            byte blue = pixels[i];
+            byte green = pixels[i + 1];
+            byte red = pixels[i + 2];
+            if (red >= 210 && green >= 210 && blue >= 210)
+                count++;
+        }
+
+        return count;
+    }
+
+    private static void AssertColorNear(Color expected, Color actual, int tolerance = 8)
+    {
+        Assert.True(
+            Math.Abs(expected.R - actual.R) <= tolerance &&
+            Math.Abs(expected.G - actual.G) <= tolerance &&
+            Math.Abs(expected.B - actual.B) <= tolerance,
+            $"Expected color near RGB({expected.R}, {expected.G}, {expected.B}), got RGB({actual.R}, {actual.G}, {actual.B}).");
+    }
+
     private static Variant SingleVariant(RmgTemplate template) =>
         Assert.Single(template.Variants ?? []);
 
@@ -592,6 +860,66 @@ public class TemplateGeneratorTests
     {
         Assert.NotNull(variant.Connections);
         return variant.Connections;
+    }
+
+    private static List<string> RoadConnectionNames(Zone zone)
+    {
+        var names = new List<string>();
+        foreach (Road road in zone.Roads ?? [])
+        {
+            AddConnectionName(road.From);
+            AddConnectionName(road.To);
+        }
+
+        return names;
+
+        void AddConnectionName(RoadEndpoint? endpoint)
+        {
+            if (endpoint?.Type == "Connection" && endpoint.Args is { Count: > 0 })
+                names.Add(endpoint.Args[0]);
+        }
+    }
+
+    private static List<List<string>> RingNeutralGapsBetweenPlayers(List<string> sequence)
+    {
+        var playerPositions = sequence
+            .Select((zoneName, index) => (zoneName, index))
+            .Where(item => item.zoneName.StartsWith("Spawn-", StringComparison.Ordinal))
+            .ToList();
+
+        var gaps = new List<List<string>>();
+        for (int i = 0; i < playerPositions.Count; i++)
+        {
+            int start = playerPositions[i].index;
+            int end = playerPositions[(i + 1) % playerPositions.Count].index;
+            var gap = new List<string>();
+
+            for (int cursor = (start + 1) % sequence.Count; cursor != end; cursor = (cursor + 1) % sequence.Count)
+                gap.Add(sequence[cursor]);
+
+            gaps.Add(gap);
+        }
+
+        return gaps;
+    }
+
+    private static Dictionary<string, int> RingPlayerDistanceTotals(List<string> sequence)
+    {
+        var playerPositions = sequence
+            .Select((zoneName, index) => (zoneName, index))
+            .Where(item => item.zoneName.StartsWith("Spawn-", StringComparison.Ordinal))
+            .ToList();
+
+        return playerPositions.ToDictionary(
+            player => player.zoneName,
+            player => playerPositions
+                .Where(other => other.zoneName != player.zoneName)
+                .Sum(other =>
+                {
+                    int clockwise = Math.Abs(player.index - other.index);
+                    return Math.Min(clockwise, sequence.Count - clockwise);
+                }),
+            StringComparer.Ordinal);
     }
 
     private static int ShortestNeutralIntermediates(Variant variant, string from, string to)

--- a/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
+++ b/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
@@ -15,7 +15,8 @@ public class TemplateGeneratorTests
             TemplateName = "Baseline Test Template",
             GameMode = "Classic",
             MapSize = 200,
-            VictoryCondition = "win_condition_2",
+            AdvancedMode = true,
+            VictoryCondition = "win_condition_5",
             HeroCountMin = 7,
             HeroCountMax = 15,
             HeroCountIncrement = 3,
@@ -218,6 +219,48 @@ public class TemplateGeneratorTests
     }
 
     [Fact]
+    public void Generate_AdvancedModeAppliesGuardRandomizationToSpawnAndNeutralZones()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            NeutralZoneCount = 2,
+            AdvancedMode = true,
+            GuardRandomization = 0.23,
+            Topology = MapTopology.Default
+        };
+
+        var zones = RequiredZones(SingleVariant(TemplateGenerator.Generate(settings)))
+            .Where(zone => zone.Name.StartsWith("Spawn-", StringComparison.Ordinal)
+                || zone.Name.StartsWith("Neutral-", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(zones);
+        Assert.All(zones, zone => Assert.Equal(0.23, zone.GuardRandomization));
+    }
+
+    [Fact]
+    public void Generate_SimpleModeIgnoresGuardRandomizationOverride()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            NeutralZoneCount = 2,
+            AdvancedMode = false,
+            GuardRandomization = 0.23,
+            Topology = MapTopology.Default
+        };
+
+        var zones = RequiredZones(SingleVariant(TemplateGenerator.Generate(settings)))
+            .Where(zone => zone.Name.StartsWith("Spawn-", StringComparison.Ordinal)
+                || zone.Name.StartsWith("Neutral-", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(zones);
+        Assert.All(zones, zone => Assert.Equal(0.05, zone.GuardRandomization));
+    }
+
+    [Fact]
     public void Generate_AdvancedNeutralCountsCreateTieredCastleAndNoCastleZones()
     {
         var settings = new GeneratorSettings
@@ -249,6 +292,16 @@ public class TemplateGeneratorTests
         Assert.Equal("MatchMainObject", zones["Neutral-D"].ZoneBiome?.Type);
         Assert.True(zones["Neutral-C"].GuardedContentValue < zones["Neutral-E"].GuardedContentValue);
         Assert.True(zones["Neutral-E"].GuardedContentValue < zones["Neutral-G"].GuardedContentValue);
+        Assert.Equal("zone_layout_sides", zones["Neutral-C"].Layout);
+        Assert.Equal("zone_layout_sides", zones["Neutral-D"].Layout);
+        Assert.Equal("zone_layout_treasure_zone", zones["Neutral-E"].Layout);
+        Assert.Equal("zone_layout_treasure_zone", zones["Neutral-F"].Layout);
+        Assert.Equal("zone_layout_center", zones["Neutral-G"].Layout);
+        Assert.Equal("zone_layout_center", zones["Neutral-H"].Layout);
+        Assert.Contains(template.ZoneLayouts ?? [], layout => layout.Name == "zone_layout_spawns");
+        Assert.Contains(template.ZoneLayouts ?? [], layout => layout.Name == "zone_layout_sides");
+        Assert.Contains(template.ZoneLayouts ?? [], layout => layout.Name == "zone_layout_treasure_zone");
+        Assert.Contains(template.ZoneLayouts ?? [], layout => layout.Name == "zone_layout_center");
 
         string json = JsonSerializer.Serialize(template, new JsonSerializerOptions { WriteIndented = true });
         Assert.DoesNotContain("\"tier\"", json, StringComparison.OrdinalIgnoreCase);
@@ -280,6 +333,116 @@ public class TemplateGeneratorTests
             Assert.Contains(connection.From, zoneNames);
             Assert.Contains(connection.To, zoneNames);
         });
+    }
+
+    [Fact]
+    public void Generate_AppliesPlayerAndNeutralZoneSizes()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            NeutralZoneCount = 2,
+            PlayerZoneSize = 2.0,
+            NeutralZoneSize = 0.5,
+            Topology = MapTopology.Default
+        };
+
+        var zones = RequiredZones(SingleVariant(TemplateGenerator.Generate(settings)));
+
+        Assert.All(zones.Where(zone => zone.Name.StartsWith("Spawn-", StringComparison.Ordinal)),
+            zone => Assert.Equal(2.0, zone.Size));
+        Assert.All(zones.Where(zone => zone.Name.StartsWith("Neutral-", StringComparison.Ordinal)),
+            zone => Assert.Equal(0.5, zone.Size));
+    }
+
+    [Fact]
+    public void KnownValues_ExperimentalMapSizesContinueOfficialIncrementThrough512()
+    {
+        Assert.Equal(240, KnownValues.MaxOfficialMapSize);
+        Assert.Equal(256, KnownValues.ExperimentalMapSizes[0]);
+        Assert.Equal(512, KnownValues.ExperimentalMapSizes[^1]);
+        Assert.Equal(17, KnownValues.ExperimentalMapSizes.Length);
+        Assert.All(KnownValues.ExperimentalMapSizes, size => Assert.Equal(0, size % 16));
+        Assert.Equal(KnownValues.MapSizes.Length + KnownValues.ExperimentalMapSizes.Length, KnownValues.AllMapSizes.Length);
+    }
+
+    [Fact]
+    public void KnownValues_VictoryConditionsUseOfficialObservedMapping()
+    {
+        Assert.Equal(
+            ["win_condition_1", "win_condition_3", "win_condition_4", "win_condition_5", "win_condition_6"],
+            KnownValues.VictoryConditionIds);
+        Assert.Contains("Gladiator Arena", KnownValues.VictoryConditionLabels);
+        Assert.Contains("Tournament", KnownValues.VictoryConditionLabels);
+    }
+
+    [Fact]
+    public void Generate_AdvancedModeWritesOfficialTournamentWinConditionSettings()
+    {
+        var settings = new GeneratorSettings
+        {
+            AdvancedMode = true,
+            VictoryCondition = "win_condition_6",
+            TournamentRoundCount = 3,
+            TournamentRoundDuration = 5,
+            TournamentFirstAnnounceDay = 7,
+            TournamentRoundInterval = 7,
+            TournamentPointsToWin = 2,
+            Topology = MapTopology.Default
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+        WinConditions? winConditions = template.GameRules?.WinConditions;
+
+        Assert.Equal("win_condition_6", template.DisplayWinCondition);
+        Assert.NotNull(winConditions);
+        Assert.True(winConditions.Tournament);
+        Assert.False(winConditions.GladiatorArena);
+        Assert.Equal([5, 5, 5], winConditions.TournamentDays);
+        Assert.Equal([7, 14, 21], winConditions.TournamentAnnounceDays);
+        Assert.Equal(2, winConditions.TournamentPointsToWin);
+        Assert.True(winConditions.TournamentSaveArmy);
+        Assert.True(winConditions.LostStartHero);
+        Assert.Equal("StartHero", winConditions.ChampionSelectRule);
+    }
+
+    [Fact]
+    public void Generate_AdvancedModeAppliesSeparateExperienceModifiers()
+    {
+        var settings = new GeneratorSettings
+        {
+            AdvancedMode = true,
+            FactionLawsExpPercent = 50,
+            AstrologyExpPercent = 200,
+            Topology = MapTopology.Default
+        };
+
+        GameRules? rules = TemplateGenerator.Generate(settings).GameRules;
+
+        Assert.NotNull(rules);
+        Assert.Equal(0.5, rules.FactionLawsExpModifier);
+        Assert.Equal(2.0, rules.AstrologyExpModifier);
+    }
+
+    [Fact]
+    public void Generate_SimpleModeIgnoresAdvancedWinConditionAndExperienceOverrides()
+    {
+        var settings = new GeneratorSettings
+        {
+            AdvancedMode = false,
+            VictoryCondition = "win_condition_6",
+            FactionLawsExpPercent = 50,
+            AstrologyExpPercent = 200,
+            Tournament = true,
+            Topology = MapTopology.Default
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.Equal("win_condition_1", template.DisplayWinCondition);
+        Assert.Equal(1.0, template.GameRules?.FactionLawsExpModifier);
+        Assert.Equal(1.0, template.GameRules?.AstrologyExpModifier);
+        Assert.Null(template.GameRules?.WinConditions?.Tournament);
     }
 
     [Fact]

--- a/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
+++ b/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
@@ -218,6 +218,145 @@ public class TemplateGeneratorTests
     }
 
     [Fact]
+    public void Generate_AdvancedNeutralCountsCreateTieredCastleAndNoCastleZones()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            AdvancedMode = true,
+            NeutralZoneCastles = 2,
+            NeutralLowNoCastleCount = 1,
+            NeutralLowCastleCount = 1,
+            NeutralMediumNoCastleCount = 1,
+            NeutralMediumCastleCount = 1,
+            NeutralHighNoCastleCount = 1,
+            NeutralHighCastleCount = 1,
+            Topology = MapTopology.Default
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+        Variant variant = SingleVariant(template);
+        var zones = RequiredZones(variant).ToDictionary(zone => zone.Name, StringComparer.Ordinal);
+
+        Assert.Equal(8, zones.Count);
+        Assert.Empty(zones["Neutral-C"].MainObjects ?? []);
+        Assert.Equal(2, zones["Neutral-D"].MainObjects?.Count);
+        Assert.Empty(zones["Neutral-E"].MainObjects ?? []);
+        Assert.Equal(2, zones["Neutral-F"].MainObjects?.Count);
+        Assert.Empty(zones["Neutral-G"].MainObjects ?? []);
+        Assert.Equal(2, zones["Neutral-H"].MainObjects?.Count);
+        Assert.Equal("MatchZone", zones["Neutral-C"].ZoneBiome?.Type);
+        Assert.Equal("MatchMainObject", zones["Neutral-D"].ZoneBiome?.Type);
+        Assert.True(zones["Neutral-C"].GuardedContentValue < zones["Neutral-E"].GuardedContentValue);
+        Assert.True(zones["Neutral-E"].GuardedContentValue < zones["Neutral-G"].GuardedContentValue);
+
+        string json = JsonSerializer.Serialize(template, new JsonSerializerOptions { WriteIndented = true });
+        Assert.DoesNotContain("\"tier\"", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"quality\"", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Generate_AdvancedModeCanCreateThirtyTwoTotalZones()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 8,
+            AdvancedMode = true,
+            NeutralLowNoCastleCount = 8,
+            NeutralLowCastleCount = 8,
+            NeutralMediumNoCastleCount = 8,
+            Topology = MapTopology.Default,
+            RandomPortals = true
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        var zones = RequiredZones(variant);
+        var zoneNames = zones.Select(zone => zone.Name).ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(32, zones.Count);
+        Assert.Contains("Neutral-AF", zoneNames);
+        Assert.All(RequiredConnections(variant), connection =>
+        {
+            Assert.Contains(connection.From, zoneNames);
+            Assert.Contains(connection.To, zoneNames);
+        });
+    }
+
+    [Fact]
+    public void Generate_WhenPlayerCastleFactionMatchingIsEnabled_ExtraCitiesMatchSpawnFaction()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            PlayerZoneCastles = 3,
+            MatchPlayerCastleFactions = true,
+            Topology = MapTopology.Default
+        };
+
+        var spawnZones = RequiredZones(SingleVariant(TemplateGenerator.Generate(settings)))
+            .Where(zone => zone.Name.StartsWith("Spawn-", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.All(spawnZones, zone =>
+        {
+            var mainObjects = zone.MainObjects ?? [];
+            Assert.Equal(3, mainObjects.Count);
+            Assert.All(mainObjects.Skip(1), mainObject =>
+            {
+                Assert.Equal("City", mainObject.Type);
+                Assert.Equal("Match", mainObject.Faction?.Type);
+                Assert.Equal(["0"], mainObject.Faction?.Args);
+            });
+        });
+    }
+
+    [Fact]
+    public void Generate_RingHonorsMinimumNeutralSeparation_WhenEnoughNeutrals()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 3,
+            NeutralZoneCount = 6,
+            MinNeutralZonesBetweenPlayers = 2,
+            Topology = MapTopology.Default
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        var spawnNames = RequiredZones(variant)
+            .Where(zone => zone.Name.StartsWith("Spawn-", StringComparison.Ordinal))
+            .Select(zone => zone.Name)
+            .ToList();
+
+        for (int i = 0; i < spawnNames.Count; i++)
+        {
+            for (int j = i + 1; j < spawnNames.Count; j++)
+                Assert.True(ShortestNeutralIntermediates(variant, spawnNames[i], spawnNames[j]) >= 2);
+        }
+    }
+
+    [Fact]
+    public void CanHonorNeutralSeparation_ReturnsFalseWhenPortalsCouldShortenPaths()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 3,
+            NeutralZoneCount = 6,
+            MinNeutralZonesBetweenPlayers = 2,
+            RandomPortals = true,
+            Topology = MapTopology.Default
+        };
+
+        Assert.False(TemplateGenerator.CanHonorNeutralSeparation(settings, settings.NeutralZoneCount));
+    }
+
+    [Fact]
+    public void TemplatePreviewPngWriter_UsesOfficialSidecarNaming()
+    {
+        Assert.Equal(@"C:\maps\My Template.png", TemplatePreviewPngWriter.GetSidecarPath(@"C:\maps\My Template.rmg.json"));
+        Assert.Equal(@"C:\maps\Other.png", TemplatePreviewPngWriter.GetSidecarPath(@"C:\maps\Other.json"));
+    }
+
+    [Fact]
     public void SettingsFile_LegacyContentDensitySeedsSplitDensitySettings()
     {
         const string json = """
@@ -290,5 +429,43 @@ public class TemplateGeneratorTests
     {
         Assert.NotNull(variant.Connections);
         return variant.Connections;
+    }
+
+    private static int ShortestNeutralIntermediates(Variant variant, string from, string to)
+    {
+        var graph = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (Connection connection in RequiredConnections(variant)
+            .Where(connection => connection.ConnectionType is "Direct" or "Portal"))
+        {
+            if (!graph.TryGetValue(connection.From, out var fromEdges))
+                graph[connection.From] = fromEdges = [];
+            if (!graph.TryGetValue(connection.To, out var toEdges))
+                graph[connection.To] = toEdges = [];
+
+            fromEdges.Add(connection.To);
+            toEdges.Add(connection.From);
+        }
+
+        var queue = new Queue<(string Zone, int Neutrals)>();
+        var best = new Dictionary<string, int>(StringComparer.Ordinal) { [from] = 0 };
+        queue.Enqueue((from, 0));
+
+        while (queue.Count > 0)
+        {
+            var (zone, neutrals) = queue.Dequeue();
+            if (!graph.TryGetValue(zone, out var neighbors)) continue;
+
+            foreach (string neighbor in neighbors)
+            {
+                int nextNeutrals = neutrals + (neighbor != to && !neighbor.StartsWith("Spawn-", StringComparison.Ordinal) ? 1 : 0);
+                if (best.TryGetValue(neighbor, out int existing) && existing <= nextNeutrals)
+                    continue;
+
+                best[neighbor] = nextNeutrals;
+                queue.Enqueue((neighbor, nextNeutrals));
+            }
+        }
+
+        return best.TryGetValue(to, out int shortest) ? shortest : int.MaxValue;
     }
 }

--- a/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
+++ b/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
@@ -1,0 +1,194 @@
+using System.Text.Json;
+using Olden_Era___Template_Editor.Models;
+using Olden_Era___Template_Editor.Services;
+using OldenEraTemplateEditor.Models;
+
+namespace Olden_Era___Template_Editor.Tests;
+
+public class TemplateGeneratorTests
+{
+    [Fact]
+    public void Generate_UsesRequestedSettingsForTemplateAndGameRules()
+    {
+        var settings = new GeneratorSettings
+        {
+            TemplateName = "Baseline Test Template",
+            GameMode = "Classic",
+            MapSize = 200,
+            VictoryCondition = "win_condition_2",
+            HeroCountMin = 7,
+            HeroCountMax = 15,
+            HeroCountIncrement = 3,
+            Topology = MapTopology.Default
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.Equal(settings.TemplateName, template.Name);
+        Assert.Equal(settings.GameMode, template.GameMode);
+        Assert.Equal(settings.MapSize, template.SizeX);
+        Assert.Equal(settings.MapSize, template.SizeZ);
+        Assert.Equal(settings.VictoryCondition, template.DisplayWinCondition);
+        Assert.Equal("custom_generated_template", template.Description);
+        Assert.NotNull(template.GameRules);
+        Assert.Equal(settings.HeroCountMin, template.GameRules.HeroCountMin);
+        Assert.Equal(settings.HeroCountMax, template.GameRules.HeroCountMax);
+        Assert.Equal(settings.HeroCountIncrement, template.GameRules.HeroCountIncrement);
+        Assert.NotEmpty(template.ZoneLayouts ?? []);
+        Assert.NotEmpty(template.ContentCountLimits ?? []);
+    }
+
+    [Fact]
+    public void Generate_DefaultTopologyCreatesExpectedZonesAndRingConnections()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 3,
+            NeutralZoneCount = 2,
+            PlayerZoneCastles = 2,
+            NeutralZoneCastles = 1,
+            Topology = MapTopology.Default,
+            RandomPortals = false
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        var zones = RequiredZones(variant);
+        var connections = RequiredConnections(variant);
+
+        Assert.Equal(5, zones.Count);
+        Assert.Equal(3, zones.Count(zone => zone.Name.StartsWith("Spawn-", StringComparison.Ordinal)));
+        Assert.Equal(2, zones.Count(zone => zone.Name.StartsWith("Neutral-", StringComparison.Ordinal)));
+        Assert.Equal(5, connections.Count);
+        Assert.All(connections, connection =>
+        {
+            Assert.StartsWith("Ring-", connection.Name);
+            Assert.Equal("Direct", connection.ConnectionType);
+        });
+        Assert.All(zones.Where(zone => zone.Name.StartsWith("Spawn-", StringComparison.Ordinal)),
+            zone => Assert.Equal(2, zone.MainObjects?.Count));
+        Assert.All(zones.Where(zone => zone.Name.StartsWith("Neutral-", StringComparison.Ordinal)),
+            zone => Assert.Single(zone.MainObjects ?? []));
+    }
+
+    [Fact]
+    public void Generate_WhenRoadsAreDisabledLeavesZoneRoadListsEmpty()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            NeutralZoneCount = 1,
+            PlayerZoneCastles = 3,
+            NeutralZoneCastles = 2,
+            SpawnRemoteFootholds = true,
+            GenerateRoads = false,
+            Topology = MapTopology.Default
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+
+        Assert.All(RequiredZones(variant), zone => Assert.Empty(zone.Roads ?? []));
+    }
+
+    [Fact]
+    public void Generate_WithPlayerIsolationAndNeutralZonesDoesNotCreateDirectPlayerConnections()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            NeutralZoneCount = 2,
+            NoDirectPlayerConnections = true,
+            Topology = MapTopology.Default
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        var playerToPlayerConnections = RequiredConnections(variant)
+            .Where(connection =>
+                connection.From.StartsWith("Spawn-", StringComparison.Ordinal) &&
+                connection.To.StartsWith("Spawn-", StringComparison.Ordinal));
+
+        Assert.Empty(playerToPlayerConnections);
+    }
+
+    [Fact]
+    public void Generate_WithRandomPortalsAddsOnePortalPerZone()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            NeutralZoneCount = 2,
+            RandomPortals = true,
+            Topology = MapTopology.Default
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        var zones = RequiredZones(variant);
+        var portals = RequiredConnections(variant)
+            .Where(connection => connection.ConnectionType == "Portal")
+            .ToList();
+
+        Assert.Equal(zones.Count, portals.Count);
+        Assert.All(portals, portal =>
+        {
+            Assert.True(portal.Road);
+            Assert.NotEmpty(portal.PortalPlacementRulesFrom ?? []);
+            Assert.NotEmpty(portal.PortalPlacementRulesTo ?? []);
+        });
+    }
+
+    [Fact]
+    public void Generate_CanSerializeAndDeserializeRmgJson()
+    {
+        var settings = new GeneratorSettings
+        {
+            TemplateName = "Round Trip Template",
+            PlayerCount = 2,
+            NeutralZoneCount = 1,
+            Topology = MapTopology.Default
+        };
+
+        RmgTemplate generated = TemplateGenerator.Generate(settings);
+        string json = JsonSerializer.Serialize(generated, new JsonSerializerOptions { WriteIndented = true });
+        RmgTemplate? deserialized = JsonSerializer.Deserialize<RmgTemplate>(json);
+
+        Assert.Contains("\"name\": \"Round Trip Template\"", json, StringComparison.Ordinal);
+        Assert.NotNull(deserialized);
+        Assert.Equal(generated.Name, deserialized.Name);
+        Assert.Single(deserialized.Variants ?? []);
+    }
+
+    [Fact]
+    public void Generate_ConnectionsReferToGeneratedZones()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 4,
+            NeutralZoneCount = 3,
+            RandomPortals = true,
+            Topology = MapTopology.Default
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        var zoneNames = RequiredZones(variant).Select(zone => zone.Name).ToHashSet(StringComparer.Ordinal);
+
+        Assert.All(RequiredConnections(variant), connection =>
+        {
+            Assert.Contains(connection.From, zoneNames);
+            Assert.Contains(connection.To, zoneNames);
+        });
+    }
+
+    private static Variant SingleVariant(RmgTemplate template) =>
+        Assert.Single(template.Variants ?? []);
+
+    private static List<Zone> RequiredZones(Variant variant)
+    {
+        Assert.NotNull(variant.Zones);
+        return variant.Zones;
+    }
+
+    private static List<Connection> RequiredConnections(Variant variant)
+    {
+        Assert.NotNull(variant.Connections);
+        return variant.Connections;
+    }
+}

--- a/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
+++ b/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
@@ -136,6 +136,106 @@ public class TemplateGeneratorTests
     }
 
     [Fact]
+    public void Generate_AppliesResourceAndStructureDensitySeparately()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            NeutralZoneCount = 2,
+            MapSize = 160,
+            Topology = MapTopology.Default,
+            ResourceDensityPercent = 50,
+            StructureDensityPercent = 150
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        Zone spawnZone = RequiredZones(variant)
+            .First(zone => zone.Name.StartsWith("Spawn-", StringComparison.Ordinal));
+
+        Assert.Equal(300000, spawnZone.GuardedContentValue);
+        Assert.Equal(3000, spawnZone.GuardedContentValuePerArea);
+        Assert.Equal(75000, spawnZone.UnguardedContentValue);
+        Assert.Equal(600, spawnZone.UnguardedContentValuePerArea);
+        Assert.Equal(40000, spawnZone.ResourcesValue);
+        Assert.Equal(300, spawnZone.ResourcesValuePerArea);
+    }
+
+    [Fact]
+    public void Generate_AppliesZoneNeutralStrengthToZoneAndMainObjectGuardsOnly()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            NeutralZoneCount = 2,
+            MapSize = 160,
+            PlayerZoneCastles = 2,
+            NeutralZoneCastles = 2,
+            Topology = MapTopology.Default,
+            NeutralStackStrengthPercent = 200,
+            BorderGuardStrengthPercent = 100
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        var zones = RequiredZones(variant);
+        Zone spawnZone = zones.First(zone => zone.Name.StartsWith("Spawn-", StringComparison.Ordinal));
+        Zone neutralZone = zones.First(zone => zone.Name.StartsWith("Neutral-", StringComparison.Ordinal));
+
+        Assert.Equal(2.0, spawnZone.GuardMultiplier);
+        Assert.Equal([10000, 5000], spawnZone.MainObjects?.Select(mainObject => mainObject.GuardValue).ToArray());
+        Assert.Equal(2.6, neutralZone.GuardMultiplier);
+        Assert.Equal([20000, 10000], neutralZone.MainObjects?.Select(mainObject => mainObject.GuardValue).ToArray());
+        Assert.All(RequiredConnections(variant), connection => Assert.Equal(30000, connection.GuardValue));
+    }
+
+    [Fact]
+    public void Generate_AppliesBorderGuardStrengthToDirectAndPortalConnectionsOnly()
+    {
+        var settings = new GeneratorSettings
+        {
+            PlayerCount = 2,
+            NeutralZoneCount = 2,
+            MapSize = 160,
+            RandomPortals = true,
+            Topology = MapTopology.Default,
+            NeutralStackStrengthPercent = 100,
+            BorderGuardStrengthPercent = 50
+        };
+
+        Variant variant = SingleVariant(TemplateGenerator.Generate(settings));
+        Zone spawnZone = RequiredZones(variant)
+            .First(zone => zone.Name.StartsWith("Spawn-", StringComparison.Ordinal));
+        var directConnections = RequiredConnections(variant)
+            .Where(connection => connection.ConnectionType == "Direct")
+            .ToList();
+        var portalConnections = RequiredConnections(variant)
+            .Where(connection => connection.ConnectionType == "Portal")
+            .ToList();
+
+        Assert.Equal(1.0, spawnZone.GuardMultiplier);
+        Assert.Equal(5000, Assert.Single(spawnZone.MainObjects ?? []).GuardValue);
+        Assert.All(directConnections, connection => Assert.Equal(15000, connection.GuardValue));
+        Assert.All(portalConnections, connection => Assert.Equal(12500, connection.GuardValue));
+    }
+
+    [Fact]
+    public void SettingsFile_LegacyContentDensitySeedsSplitDensitySettings()
+    {
+        const string json = """
+            {
+              "contentDensity": 130
+            }
+            """;
+
+        SettingsFile? settings = JsonSerializer.Deserialize<SettingsFile>(json);
+
+        Assert.NotNull(settings);
+        Assert.Equal(130, settings.EffectiveResourceDensityPercent);
+        Assert.Equal(130, settings.EffectiveStructureDensityPercent);
+        Assert.Equal(100, settings.NeutralStackStrengthPercent);
+        Assert.Equal(100, settings.BorderGuardStrengthPercent);
+    }
+
+    [Fact]
     public void Generate_CanSerializeAndDeserializeRmgJson()
     {
         var settings = new GeneratorSettings

--- a/Olden Era - Template Editor.slnx
+++ b/Olden Era - Template Editor.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="Olden Era - Template Editor/Olden Era - Template Editor.csproj" />
+  <Project Path="Olden Era - Template Editor.Tests/Olden Era - Template Editor.Tests.csproj" />
 </Solution>

--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -774,6 +774,16 @@
             Text="Note: Roads are only generated within zones that have at least one castle. Neutral zones with 0 castles will not have roads, even if this option is enabled."/>
                                 <CheckBox x:Name="ChkSpawnFootholds" Content="Spawn remote footholds" IsChecked="True" Margin="0,6,0,0"/>
                         <CheckBox x:Name="ChkRandomPortals"  Content="Always spawn portals"          Margin="0,6,0,0"/>                      
+                        <CheckBox x:Name="ChkBalancedZonePlacement"
+                                  Content="Balance zone placement [EXPERIMENTAL]"
+                                  Margin="0,6,0,0"
+                                  Checked="ChkOption_Changed" Unchecked="ChkOption_Changed"/>
+                        <TextBlock x:Name="TxtBalancedZonePlacementDesc"
+                                   Visibility="Collapsed"
+                                   Foreground="{StaticResource BrushTextDim}"
+                                   FontSize="13" TextWrapping="Wrap"
+                                   Margin="25,3,0,0"
+                                   Text="Spreads players and neutral zone tiers more evenly across structured layouts. Random layout uses balanced seed positions before building borders."/>
                         <CheckBox x:Name="ChkNoDirectPlayerConn"
                                   Content="Connect via neutral zones only [EXPERIMENTAL]"
                                   Margin="0,6,0,0"

--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -142,8 +142,23 @@
                             <Label Grid.Row="0" Grid.Column="0" Content="Template Name"/>
                             <TextBox Grid.Row="0" Grid.Column="1" x:Name="TxtTemplateName" Text="Custom Template"/>
                             <Label Grid.Row="2" Grid.Column="0" Content="Map Size"/>
-                            <ComboBox Grid.Row="2" Grid.Column="1" x:Name="CmbMapSize"
-                                      SelectionChanged="CmbMapSize_SelectionChanged"/>
+                            <StackPanel Grid.Row="2" Grid.Column="1">
+                                <ComboBox x:Name="CmbMapSize"
+                                          SelectionChanged="CmbMapSize_SelectionChanged"/>
+                                <CheckBox x:Name="ChkExperimentalMapSizes"
+                                          Content="Experimental large map sizes"
+                                          Margin="0,6,0,0"
+                                          Visibility="Collapsed"
+                                          Checked="ChkExperimentalMapSizes_Changed"
+                                          Unchecked="ChkExperimentalMapSizes_Changed"/>
+                                <TextBlock x:Name="TxtExperimentalMapSizeWarning"
+                                           Foreground="{StaticResource BrushTextDim}"
+                                           FontSize="11"
+                                           TextWrapping="Wrap"
+                                           Margin="0,4,0,0"
+                                           Visibility="Collapsed"
+                                           Text="Adds 256x256 through 512x512. Official templates top out at 240x240, so larger maps may fail, freeze, or behave unpredictably in game."/>
+                            </StackPanel>
                             <DockPanel Grid.Row="4" Grid.Column="0">
                                 <Label Content="Players" DockPanel.Dock="Left"/>
                                 <TextBlock x:Name="TxtPlayers" Text="2" DockPanel.Dock="Right"
@@ -363,6 +378,64 @@
                                       Checked="ChkOption_Changed"
                                       Unchecked="ChkOption_Changed"/>
                         </StackPanel>
+                        <StackPanel x:Name="PnlAdvancedZoneSizes"
+                                    Visibility="Collapsed"
+                                    Margin="0,12,0,0">
+                            <TextBlock Text="Advanced zone tuning"
+                                       Style="{StaticResource SectionHeader}"
+                                       Margin="0,0,0,4"/>
+                            <TextBlock Foreground="{StaticResource BrushTextDim}"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,6"
+                                       Text="Relative region weights and guard variance used by the game layout."/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="230"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="4"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="4"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <DockPanel Grid.Row="0" Grid.Column="0">
+                                    <Label Content="Player zone size" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtPlayerZoneSize" Text="1.00x" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="0" Grid.Column="1" x:Name="SldPlayerZoneSize"
+                                        Minimum="0.1" Maximum="2" Value="1"
+                                        TickFrequency="0.05" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+
+                                <DockPanel Grid.Row="2" Grid.Column="0">
+                                    <Label Content="Neutral zone size" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtNeutralZoneSize" Text="1.00x" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="2" Grid.Column="1" x:Name="SldNeutralZoneSize"
+                                        Minimum="0.1" Maximum="2" Value="1"
+                                        TickFrequency="0.05" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+
+                                <DockPanel Grid.Row="4" Grid.Column="0">
+                                    <Label Content="Guard randomization" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtGuardRandomization" Text="5%" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="4" Grid.Column="1" x:Name="SldGuardRandomization"
+                                        Minimum="0" Maximum="50" Value="5"
+                                        TickFrequency="1" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+                            </Grid>
+                        </StackPanel>
                         <StackPanel x:Name="PnlAdvancedNeutralZones"
                                     Visibility="Collapsed"
                                     Margin="0,12,0,0">
@@ -485,6 +558,212 @@
                                        Margin="0,4,0,0"
                                        Text="Honored only when the selected layout, neutral zone total, and portal settings can support it; otherwise generation uses the normal connection layout."/>
                         </StackPanel>
+                        <StackPanel x:Name="PnlAdvancedGameRules"
+                                    Visibility="Collapsed"
+                                    Margin="0,12,0,0">
+                            <TextBlock Text="Advanced game rules"
+                                       Style="{StaticResource SectionHeader}"
+                                       Margin="0,0,0,4"/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="230"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="6"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="4"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <Label Grid.Row="0" Grid.Column="0" Content="Win condition"/>
+                                <ComboBox Grid.Row="0" Grid.Column="1" x:Name="CmbVictory"
+                                          SelectionChanged="CmbVictory_SelectionChanged"/>
+
+                                <DockPanel Grid.Row="2" Grid.Column="0">
+                                    <Label Content="Faction laws XP" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtFactionLawsExp" Text="100%" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="2" Grid.Column="1" x:Name="SldFactionLawsExp"
+                                        Minimum="25" Maximum="200" Value="100"
+                                        TickFrequency="25" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+
+                                <DockPanel Grid.Row="4" Grid.Column="0">
+                                    <Label Content="Astrology XP" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtAstrologyExp" Text="100%" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="4" Grid.Column="1" x:Name="SldAstrologyExp"
+                                        Minimum="25" Maximum="200" Value="100"
+                                        TickFrequency="25" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+                            </Grid>
+
+                            <StackPanel Margin="0,8,0,0">
+                                <CheckBox x:Name="ChkLostStartCity"
+                                          Content="Lose when starting city is lost"
+                                          Checked="WinConditionOption_Changed"
+                                          Unchecked="WinConditionOption_Changed"/>
+                                <Grid x:Name="PnlLostStartCityDetails" Margin="18,3,0,6">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="212"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <DockPanel Grid.Column="0">
+                                        <Label Content="Lost city day" Padding="5,2" DockPanel.Dock="Left"/>
+                                        <TextBlock x:Name="TxtLostStartCityDay" Text="3" DockPanel.Dock="Right"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                    </DockPanel>
+                                    <Slider Grid.Column="1" x:Name="SldLostStartCityDay"
+                                            Minimum="1" Maximum="30" Value="3"
+                                            TickFrequency="1" IsSnapToTickEnabled="True"
+                                            ValueChanged="Slider_ValueChanged"/>
+                                </Grid>
+
+                                <CheckBox x:Name="ChkLostStartHero"
+                                          Content="Lose when starting hero is lost"
+                                          Checked="WinConditionOption_Changed"
+                                          Unchecked="WinConditionOption_Changed"/>
+
+                                <CheckBox x:Name="ChkCityHold"
+                                          Content="Win by holding a city"
+                                          Margin="0,6,0,0"
+                                          Checked="WinConditionOption_Changed"
+                                          Unchecked="WinConditionOption_Changed"/>
+                                <Grid x:Name="PnlCityHoldDetails" Margin="18,3,0,6">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="212"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <DockPanel Grid.Column="0">
+                                        <Label Content="Hold days" Padding="5,2" DockPanel.Dock="Left"/>
+                                        <TextBlock x:Name="TxtCityHoldDays" Text="6" DockPanel.Dock="Right"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                    </DockPanel>
+                                    <Slider Grid.Column="1" x:Name="SldCityHoldDays"
+                                            Minimum="1" Maximum="30" Value="6"
+                                            TickFrequency="1" IsSnapToTickEnabled="True"
+                                            ValueChanged="Slider_ValueChanged"/>
+                                </Grid>
+
+                                <CheckBox x:Name="ChkGladiatorArena"
+                                          Content="Use gladiator arena rules"
+                                          Margin="0,6,0,0"
+                                          Checked="WinConditionOption_Changed"
+                                          Unchecked="WinConditionOption_Changed"/>
+                                <Grid x:Name="PnlGladiatorDetails" Margin="18,3,0,6">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="212"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="4"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <DockPanel Grid.Row="0" Grid.Column="0">
+                                        <Label Content="Arena delay" Padding="5,2" DockPanel.Dock="Left"/>
+                                        <TextBlock x:Name="TxtGladiatorDelay" Text="30" DockPanel.Dock="Right"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                    </DockPanel>
+                                    <Slider Grid.Row="0" Grid.Column="1" x:Name="SldGladiatorDelay"
+                                            Minimum="1" Maximum="60" Value="30"
+                                            TickFrequency="1" IsSnapToTickEnabled="True"
+                                            ValueChanged="Slider_ValueChanged"/>
+                                    <DockPanel Grid.Row="2" Grid.Column="0">
+                                        <Label Content="Arena count day" Padding="5,2" DockPanel.Dock="Left"/>
+                                        <TextBlock x:Name="TxtGladiatorCountDay" Text="3" DockPanel.Dock="Right"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                    </DockPanel>
+                                    <Slider Grid.Row="2" Grid.Column="1" x:Name="SldGladiatorCountDay"
+                                            Minimum="1" Maximum="30" Value="3"
+                                            TickFrequency="1" IsSnapToTickEnabled="True"
+                                            ValueChanged="Slider_ValueChanged"/>
+                                </Grid>
+
+                                <CheckBox x:Name="ChkTournament"
+                                          Content="Use tournament rules"
+                                          Margin="0,6,0,0"
+                                          Checked="WinConditionOption_Changed"
+                                          Unchecked="WinConditionOption_Changed"/>
+                                <Grid x:Name="PnlTournamentDetails" Margin="18,3,0,0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="212"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="4"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="4"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="4"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="4"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <DockPanel Grid.Row="0" Grid.Column="0">
+                                        <Label Content="Tournament rounds" Padding="5,2" DockPanel.Dock="Left"/>
+                                        <TextBlock x:Name="TxtTournamentRoundCount" Text="3" DockPanel.Dock="Right"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                    </DockPanel>
+                                    <Slider Grid.Row="0" Grid.Column="1" x:Name="SldTournamentRoundCount"
+                                            Minimum="1" Maximum="5" Value="3"
+                                            TickFrequency="1" IsSnapToTickEnabled="True"
+                                            ValueChanged="Slider_ValueChanged"/>
+                                    <DockPanel Grid.Row="2" Grid.Column="0">
+                                        <Label Content="Round duration" Padding="5,2" DockPanel.Dock="Left"/>
+                                        <TextBlock x:Name="TxtTournamentRoundDuration" Text="3" DockPanel.Dock="Right"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                    </DockPanel>
+                                    <Slider Grid.Row="2" Grid.Column="1" x:Name="SldTournamentRoundDuration"
+                                            Minimum="1" Maximum="14" Value="3"
+                                            TickFrequency="1" IsSnapToTickEnabled="True"
+                                            ValueChanged="Slider_ValueChanged"/>
+                                    <DockPanel Grid.Row="4" Grid.Column="0">
+                                        <Label Content="First announce day" Padding="5,2" DockPanel.Dock="Left"/>
+                                        <TextBlock x:Name="TxtTournamentFirstAnnounceDay" Text="7" DockPanel.Dock="Right"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                    </DockPanel>
+                                    <Slider Grid.Row="4" Grid.Column="1" x:Name="SldTournamentFirstAnnounceDay"
+                                            Minimum="1" Maximum="60" Value="7"
+                                            TickFrequency="1" IsSnapToTickEnabled="True"
+                                            ValueChanged="Slider_ValueChanged"/>
+                                    <DockPanel Grid.Row="6" Grid.Column="0">
+                                        <Label Content="Round interval" Padding="5,2" DockPanel.Dock="Left"/>
+                                        <TextBlock x:Name="TxtTournamentRoundInterval" Text="7" DockPanel.Dock="Right"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                    </DockPanel>
+                                    <Slider Grid.Row="6" Grid.Column="1" x:Name="SldTournamentRoundInterval"
+                                            Minimum="1" Maximum="30" Value="7"
+                                            TickFrequency="1" IsSnapToTickEnabled="True"
+                                            ValueChanged="Slider_ValueChanged"/>
+                                    <DockPanel Grid.Row="8" Grid.Column="0">
+                                        <Label Content="Points to win" Padding="5,2" DockPanel.Dock="Left"/>
+                                        <TextBlock x:Name="TxtTournamentPointsToWin" Text="2" DockPanel.Dock="Right"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                    </DockPanel>
+                                    <Slider Grid.Row="8" Grid.Column="1" x:Name="SldTournamentPointsToWin"
+                                            Minimum="1" Maximum="5" Value="2"
+                                            TickFrequency="1" IsSnapToTickEnabled="True"
+                                            ValueChanged="Slider_ValueChanged"/>
+                                </Grid>
+                            </StackPanel>
+                        </StackPanel>
                                 <CheckBox x:Name="ChkGenerateRoads"  Content="Generate roads"         IsChecked="True" Margin="0,15,0,0"
           Checked="ChkOption_Changed" Unchecked="ChkOption_Changed"/>
                                 <TextBlock x:Name="TxtRoadsHint"
@@ -514,7 +793,6 @@
 
         <!-- Hidden combos required by code-behind -->
         <ComboBox Grid.Row="2" x:Name="CmbGameMode" Visibility="Collapsed"/>
-        <ComboBox Grid.Row="2" x:Name="CmbVictory"  Visibility="Collapsed"/>
         <TextBlock Grid.Row="2" x:Name="TxtAppTitle" Visibility="Collapsed"/>
 
         <!-- ════════ VALIDATION ════════════════════════════════════════ -->

--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -95,6 +95,11 @@
             <Button Content="📂  Open"    Width="80"  Margin="0,0,6,0" Click="BtnOpen_Click"   Style="{StaticResource ToolbarButton}" ToolTip="Open (Ctrl+O)"/>
             <Button Content="💾  Save"    Width="80"  Margin="0,0,6,0" Click="BtnSave_Click"   Style="{StaticResource ToolbarButton}" ToolTip="Save (Ctrl+S)"/>
             <Button Content="💾  Save As" Width="96"  Margin="0,0,0,0" Click="BtnSaveAs_Click" Style="{StaticResource ToolbarButton}" ToolTip="Save As (Ctrl+Shift+S)"/>
+            <CheckBox x:Name="ChkAdvancedMode"
+                      Content="Advanced mode"
+                      Margin="18,4,0,0"
+                      Checked="ChkAdvancedMode_Changed"
+                      Unchecked="ChkAdvancedMode_Changed"/>
         </StackPanel>
 
         <!-- ════════ HEADER ════════════════════════════════════════════ -->
@@ -223,6 +228,20 @@
                                     TickFrequency="1" IsSnapToTickEnabled="True"
                                     ValueChanged="Slider_ValueChanged"/>
                         </Grid>
+                        <StackPanel Margin="0,8,0,0">
+                            <TextBlock Foreground="{StaticResource BrushTextDim}"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Text="Min Heroes: Initial Max Number of Heroes (with 1 castle)."/>
+                            <TextBlock Foreground="{StaticResource BrushTextDim}"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Text="Max Heroes: Max Number of Heroes (with all castles)."/>
+                            <TextBlock Foreground="{StaticResource BrushTextDim}"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Text="Increase heroes / castle: How Much The Hero Cap Increases Per Castle."/>
+                        </StackPanel>
                     </StackPanel>
                 </Border>
             </Grid>
@@ -235,6 +254,7 @@
 
                 <!-- ZONE CONFIGURATION -->
                 <Border Grid.Row="0" Style="{StaticResource SectionBorder}">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                     <StackPanel>
                         <TextBlock Text="◆  ZONE CONFIGURATION" Style="{StaticResource SectionHeader}"/>
                         <Grid>
@@ -258,7 +278,7 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <DockPanel Grid.Row="0" Grid.Column="0">
+                            <DockPanel Grid.Row="0" Grid.Column="0" x:Name="PnlSimpleNeutralCountLabel">
                                 <Label Content="Additional Neutral Zones" DockPanel.Dock="Left"/>
                                 <TextBlock x:Name="TxtNeutral" Text="0" DockPanel.Dock="Right"
                                            HorizontalAlignment="Right" VerticalAlignment="Center"
@@ -335,6 +355,136 @@
                                     TickFrequency="5" IsSnapToTickEnabled="True"
                                     ValueChanged="Slider_ValueChanged"/>
                         </Grid>
+                        <StackPanel x:Name="PnlPlayerCastleFactionOption"
+                                    Visibility="Collapsed"
+                                    Margin="0,10,0,0">
+                            <CheckBox x:Name="ChkMatchPlayerCastleFactions"
+                                      Content="Use one faction for all castles in each player zone"
+                                      Checked="ChkOption_Changed"
+                                      Unchecked="ChkOption_Changed"/>
+                        </StackPanel>
+                        <StackPanel x:Name="PnlAdvancedNeutralZones"
+                                    Visibility="Collapsed"
+                                    Margin="0,12,0,0">
+                            <TextBlock Text="Advanced neutral zones"
+                                       Style="{StaticResource SectionHeader}"
+                                       Margin="0,0,0,4"/>
+                            <TextBlock Foreground="{StaticResource BrushTextDim}"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,6"
+                                       Text="With-castle neutral zones use the Castles / Neutral Zone value. Each advanced slider is capped at 8; total zones are capped at 32 in advanced mode."/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="230"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="4"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="4"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="4"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="4"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="4"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <DockPanel Grid.Row="0" Grid.Column="0">
+                                    <Label Content="Low neutral, no castle" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtNeutralLowNoCastle" Text="0" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="0" Grid.Column="1" x:Name="SldNeutralLowNoCastle"
+                                        Minimum="0" Maximum="8" Value="0"
+                                        TickFrequency="1" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+
+                                <DockPanel Grid.Row="2" Grid.Column="0">
+                                    <Label Content="Low neutral, castle" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtNeutralLowCastle" Text="0" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="2" Grid.Column="1" x:Name="SldNeutralLowCastle"
+                                        Minimum="0" Maximum="8" Value="0"
+                                        TickFrequency="1" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+
+                                <DockPanel Grid.Row="4" Grid.Column="0">
+                                    <Label Content="Medium neutral, no castle" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtNeutralMediumNoCastle" Text="0" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="4" Grid.Column="1" x:Name="SldNeutralMediumNoCastle"
+                                        Minimum="0" Maximum="8" Value="0"
+                                        TickFrequency="1" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+
+                                <DockPanel Grid.Row="6" Grid.Column="0">
+                                    <Label Content="Medium neutral, castle" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtNeutralMediumCastle" Text="0" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="6" Grid.Column="1" x:Name="SldNeutralMediumCastle"
+                                        Minimum="0" Maximum="8" Value="0"
+                                        TickFrequency="1" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+
+                                <DockPanel Grid.Row="8" Grid.Column="0">
+                                    <Label Content="High neutral, no castle" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtNeutralHighNoCastle" Text="0" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="8" Grid.Column="1" x:Name="SldNeutralHighNoCastle"
+                                        Minimum="0" Maximum="8" Value="0"
+                                        TickFrequency="1" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+
+                                <DockPanel Grid.Row="10" Grid.Column="0">
+                                    <Label Content="High neutral, castle" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtNeutralHighCastle" Text="0" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Row="10" Grid.Column="1" x:Name="SldNeutralHighCastle"
+                                        Minimum="0" Maximum="8" Value="0"
+                                        TickFrequency="1" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+                            </Grid>
+                        </StackPanel>
+                        <StackPanel x:Name="PnlAdvancedSeparation"
+                                    Visibility="Collapsed"
+                                    Margin="0,12,0,0">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="230"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <DockPanel Grid.Column="0">
+                                    <Label Content="Min neutrals between players" DockPanel.Dock="Left"/>
+                                    <TextBlock x:Name="TxtMinNeutralBetweenPlayers" Text="0" DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
+                                </DockPanel>
+                                <Slider Grid.Column="1" x:Name="SldMinNeutralBetweenPlayers"
+                                        Minimum="0" Maximum="8" Value="0"
+                                        TickFrequency="1" IsSnapToTickEnabled="True"
+                                        ValueChanged="Slider_ValueChanged"/>
+                            </Grid>
+                            <TextBlock Foreground="{StaticResource BrushTextDim}"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Margin="0,4,0,0"
+                                       Text="Honored only when the selected layout, neutral zone total, and portal settings can support it; otherwise generation uses the normal connection layout."/>
+                        </StackPanel>
                                 <CheckBox x:Name="ChkGenerateRoads"  Content="Generate roads"         IsChecked="True" Margin="0,15,0,0"
           Checked="ChkOption_Changed" Unchecked="ChkOption_Changed"/>
                                 <TextBlock x:Name="TxtRoadsHint"
@@ -357,6 +507,7 @@
                                    Margin="25,3,0,0"
                                    Text="The game tries to connect player zones to neutral zones only. If no neutral zone borders a player zone, it will fall back to connecting directly to another player zone."/>
                     </StackPanel>
+                    </ScrollViewer>
                 </Border>
             </Grid>
         </Grid>

--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -5,8 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Olden Era - Simple Template Generator"
-        Height="610" Width="960"
-        MinHeight="550" MinWidth="800"
+        Height="700" Width="960"
+        MinHeight="650" MinWidth="800"
         WindowStyle="None"
         ResizeMode="NoResize"
         Background="#1A1510"
@@ -250,6 +250,12 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="8"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="8"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="8"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="8"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
                             <DockPanel Grid.Row="0" Grid.Column="0">
@@ -286,14 +292,47 @@
                                     ValueChanged="Slider_ValueChanged"/>
 
                             <DockPanel Grid.Row="6" Grid.Column="0">
-                                <Label Content="Resource/Structure spawn rate" DockPanel.Dock="Left"/>
-                                <TextBlock x:Name="TxtContentDensity" Text="100%" DockPanel.Dock="Right"
+                                <Label Content="Resource spawn rate" DockPanel.Dock="Left"/>
+                                <TextBlock x:Name="TxtResourceDensity" Text="100%" DockPanel.Dock="Right"
                                            HorizontalAlignment="Right" VerticalAlignment="Center"
                                            Margin="0,0,10,0" Style="{StaticResource ValueText}"/>
                             </DockPanel>
-                            <Slider Grid.Row="6" Grid.Column="1" x:Name="SldContentDensity"
+                            <Slider Grid.Row="6" Grid.Column="1" x:Name="SldResourceDensity"
                                     Minimum="20" Maximum="200" Value="100"
                                     TickFrequency="10" IsSnapToTickEnabled="True"
+                                    ValueChanged="Slider_ValueChanged"/>
+
+                            <DockPanel Grid.Row="8" Grid.Column="0">
+                                <Label Content="Structure spawn rate" DockPanel.Dock="Left"/>
+                                <TextBlock x:Name="TxtStructureDensity" Text="100%" DockPanel.Dock="Right"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"
+                                           Margin="0,0,10,0" Style="{StaticResource ValueText}"/>
+                            </DockPanel>
+                            <Slider Grid.Row="8" Grid.Column="1" x:Name="SldStructureDensity"
+                                    Minimum="20" Maximum="200" Value="100"
+                                    TickFrequency="10" IsSnapToTickEnabled="True"
+                                    ValueChanged="Slider_ValueChanged"/>
+
+                            <DockPanel Grid.Row="10" Grid.Column="0">
+                                <Label Content="Zone neutral strength" DockPanel.Dock="Left"/>
+                                <TextBlock x:Name="TxtNeutralStackStrength" Text="100%" DockPanel.Dock="Right"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"
+                                           Margin="0,0,10,0" Style="{StaticResource ValueText}"/>
+                            </DockPanel>
+                            <Slider Grid.Row="10" Grid.Column="1" x:Name="SldNeutralStackStrength"
+                                    Minimum="25" Maximum="300" Value="100"
+                                    TickFrequency="5" IsSnapToTickEnabled="True"
+                                    ValueChanged="Slider_ValueChanged"/>
+
+                            <DockPanel Grid.Row="12" Grid.Column="0">
+                                <Label Content="Border/portal strength" DockPanel.Dock="Left"/>
+                                <TextBlock x:Name="TxtBorderGuardStrength" Text="100%" DockPanel.Dock="Right"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"
+                                           Margin="0,0,10,0" Style="{StaticResource ValueText}"/>
+                            </DockPanel>
+                            <Slider Grid.Row="12" Grid.Column="1" x:Name="SldBorderGuardStrength"
+                                    Minimum="0" Maximum="300" Value="100"
+                                    TickFrequency="5" IsSnapToTickEnabled="True"
                                     ValueChanged="Slider_ValueChanged"/>
                         </Grid>
                                 <CheckBox x:Name="ChkGenerateRoads"  Content="Generate roads"         IsChecked="True" Margin="0,15,0,0"

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -30,6 +30,7 @@ namespace Olden_Era___Template_Editor
         // Currently open settings file path (null = unsaved / untitled)
         private string? _currentSettingsPath = null;
         private bool _isDirty = false;
+        private bool _isRefreshingMapSizes = false;
         private string _baseTitle = string.Empty;
 
         private static readonly (MapTopology Topology, string Label, string Description)[] TopologyOptions =
@@ -54,8 +55,7 @@ namespace Olden_Era___Template_Editor
 
             CmbGameMode.ItemsSource = KnownValues.GameModes;
             CmbGameMode.SelectedIndex = 0;
-            CmbMapSize.ItemsSource = KnownValues.MapSizes.Select(s => $"{s}x{s}").ToList();
-            CmbMapSize.SelectedItem = "160x160";
+            RefreshMapSizeOptions(160);
             CmbVictory.ItemsSource = KnownValues.VictoryConditionLabels;
             CmbVictory.SelectedIndex = 0; // Classic (win_condition_1)
             CmbTopology.ItemsSource = TopologyOptions.Select(t => t.Label).ToList();
@@ -174,6 +174,8 @@ namespace Olden_Era___Template_Editor
             TxtStructureDensity.Text = $"{(int)SldStructureDensity.Value}%";
             TxtNeutralStackStrength.Text = $"{(int)SldNeutralStackStrength.Value}%";
             TxtBorderGuardStrength.Text = $"{(int)SldBorderGuardStrength.Value}%";
+            TxtFactionLawsExp.Text = $"{(int)SldFactionLawsExp.Value}%";
+            TxtAstrologyExp.Text = $"{(int)SldAstrologyExp.Value}%";
             TxtNeutralLowNoCastle.Text = ((int)SldNeutralLowNoCastle.Value).ToString();
             TxtNeutralLowCastle.Text = ((int)SldNeutralLowCastle.Value).ToString();
             TxtNeutralMediumNoCastle.Text = ((int)SldNeutralMediumNoCastle.Value).ToString();
@@ -181,6 +183,18 @@ namespace Olden_Era___Template_Editor
             TxtNeutralHighNoCastle.Text = ((int)SldNeutralHighNoCastle.Value).ToString();
             TxtNeutralHighCastle.Text = ((int)SldNeutralHighCastle.Value).ToString();
             TxtMinNeutralBetweenPlayers.Text = ((int)SldMinNeutralBetweenPlayers.Value).ToString();
+            TxtPlayerZoneSize.Text = $"{SldPlayerZoneSize.Value:F2}x";
+            TxtNeutralZoneSize.Text = $"{SldNeutralZoneSize.Value:F2}x";
+            TxtGuardRandomization.Text = $"{(int)SldGuardRandomization.Value}%";
+            TxtLostStartCityDay.Text = ((int)SldLostStartCityDay.Value).ToString();
+            TxtCityHoldDays.Text = ((int)SldCityHoldDays.Value).ToString();
+            TxtGladiatorDelay.Text = ((int)SldGladiatorDelay.Value).ToString();
+            TxtGladiatorCountDay.Text = ((int)SldGladiatorCountDay.Value).ToString();
+            TxtTournamentRoundCount.Text = ((int)SldTournamentRoundCount.Value).ToString();
+            TxtTournamentRoundDuration.Text = ((int)SldTournamentRoundDuration.Value).ToString();
+            TxtTournamentFirstAnnounceDay.Text = ((int)SldTournamentFirstAnnounceDay.Value).ToString();
+            TxtTournamentRoundInterval.Text = ((int)SldTournamentRoundInterval.Value).ToString();
+            TxtTournamentPointsToWin.Text = ((int)SldTournamentPointsToWin.Value).ToString();
         }
 
         private bool Validate()
@@ -214,8 +228,12 @@ namespace Olden_Era___Template_Editor
 
             var warnings = new System.Collections.Generic.List<string>();
 
-            if (players + neutral > 4 && CmbMapSize.SelectedItem is string selStr && int.TryParse(selStr.Split('x')[0], out int selectedSize) && selectedSize < 128)
+            int selectedMapSize = SelectedMapSize();
+            if (players + neutral > 4 && selectedMapSize < 128)
                 warnings.Add("⚠️ Using a small map with many zones may freeze the game while loading the map. Consider using a larger map size.");
+
+            if (selectedMapSize > KnownValues.MaxOfficialMapSize)
+                warnings.Add("Experimental map sizes above 240x240 are not confirmed by official templates; generated maps may fail, freeze, or behave unpredictably in game.");
 
             int minNeutralBetweenPlayers = (int)SldMinNeutralBetweenPlayers.Value;
             if (ChkAdvancedMode.IsChecked == true && minNeutralBetweenPlayers > 0)
@@ -252,6 +270,51 @@ namespace Olden_Era___Template_Editor
                 + (int)SldNeutralHighCastle.Value;
         }
 
+        private int SelectedMapSize() =>
+            CmbMapSize.SelectedItem is string sizeStr && int.TryParse(sizeStr.Split('x')[0], out int parsedSize)
+                ? parsedSize
+                : 160;
+
+        private static string FormatMapSize(int size) =>
+            KnownValues.IsExperimentalMapSize(size) ? $"{size}x{size} (Experimental)" : $"{size}x{size}";
+
+        private static double GuardRandomizationPercent(double guardRandomization)
+        {
+            if (double.IsNaN(guardRandomization) || double.IsInfinity(guardRandomization))
+                return 5.0;
+
+            return Math.Clamp(guardRandomization * 100.0, 0.0, 50.0);
+        }
+
+        private void RefreshMapSizeOptions(int? requestedSize = null)
+        {
+            if (CmbMapSize == null) return;
+
+            int selectedSize = requestedSize ?? SelectedMapSize();
+            bool includeExperimental = ChkAdvancedMode?.IsChecked == true && ChkExperimentalMapSizes?.IsChecked == true;
+            int[] sizes = includeExperimental ? KnownValues.AllMapSizes : KnownValues.MapSizes;
+
+            if (!includeExperimental && KnownValues.IsExperimentalMapSize(selectedSize))
+                selectedSize = KnownValues.MaxOfficialMapSize;
+            else if (!sizes.Contains(selectedSize))
+                selectedSize = KnownValues.MapSizes.Contains(selectedSize) ? selectedSize : 160;
+
+            _isRefreshingMapSizes = true;
+            try
+            {
+                CmbMapSize.ItemsSource = sizes.Select(FormatMapSize).ToList();
+                CmbMapSize.SelectedItem = FormatMapSize(selectedSize);
+                if (CmbMapSize.SelectedIndex < 0)
+                    CmbMapSize.SelectedItem = FormatMapSize(160);
+            }
+            finally
+            {
+                _isRefreshingMapSizes = false;
+            }
+
+            UpdateExperimentalMapSizeWarningVisibility();
+        }
+
         private void CmbTopology_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (!IsInitialized) return;
@@ -273,7 +336,8 @@ namespace Olden_Era___Template_Editor
 
         private void CmbMapSize_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (!IsInitialized) return;
+            if (!IsInitialized || _isRefreshingMapSizes) return;
+            UpdateExperimentalMapSizeWarningVisibility();
             MarkDirty();
             Validate();
         }
@@ -284,6 +348,15 @@ namespace Olden_Era___Template_Editor
             UpdateIsolateDescVisibility();
             UpdateRoadsHintVisibility();
             UpdatePlayerCastleFactionVisibility();
+            UpdateWinConditionDetailVisibility();
+            MarkDirty();
+            Validate();
+        }
+
+        private void WinConditionOption_Changed(object sender, RoutedEventArgs e)
+        {
+            if (!IsInitialized) return;
+            UpdateWinConditionDetailVisibility();
             MarkDirty();
             Validate();
         }
@@ -302,6 +375,15 @@ namespace Olden_Era___Template_Editor
             UpdateAdvancedModeVisibility();
             UpdateValueLabels();
             UpdateRoadsHintVisibility();
+            UpdateWinConditionDetailVisibility();
+            MarkDirty();
+            Validate();
+        }
+
+        private void ChkExperimentalMapSizes_Changed(object sender, RoutedEventArgs e)
+        {
+            if (!IsInitialized) return;
+            RefreshMapSizeOptions();
             MarkDirty();
             Validate();
         }
@@ -319,9 +401,110 @@ namespace Olden_Era___Template_Editor
             if (PnlAdvancedNeutralZones == null) return;
             bool advanced = ChkAdvancedMode.IsChecked == true;
             PnlAdvancedNeutralZones.Visibility = advanced ? Visibility.Visible : Visibility.Collapsed;
+            PnlAdvancedZoneSizes.Visibility = advanced ? Visibility.Visible : Visibility.Collapsed;
             PnlAdvancedSeparation.Visibility = advanced ? Visibility.Visible : Visibility.Collapsed;
+            PnlAdvancedGameRules.Visibility = advanced ? Visibility.Visible : Visibility.Collapsed;
             PnlSimpleNeutralCountLabel.Visibility = advanced ? Visibility.Collapsed : Visibility.Visible;
             SldNeutral.Visibility = advanced ? Visibility.Collapsed : Visibility.Visible;
+            ChkExperimentalMapSizes.Visibility = advanced ? Visibility.Visible : Visibility.Collapsed;
+            if (!advanced)
+                ChkExperimentalMapSizes.IsChecked = false;
+            RefreshMapSizeOptions();
+            UpdateWinConditionDetailVisibility();
+        }
+
+        private void CmbVictory_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!IsInitialized) return;
+
+            int idx = CmbVictory.SelectedIndex;
+            if (idx >= 0 && idx < KnownValues.VictoryConditionIds.Length)
+                ApplyVictoryPreset(KnownValues.VictoryConditionIds[idx]);
+
+            UpdateWinConditionDetailVisibility();
+            MarkDirty();
+            Validate();
+        }
+
+        private void ApplyVictoryPreset(string victoryCondition)
+        {
+            ChkLostStartCity.IsChecked = false;
+            ChkLostStartHero.IsChecked = false;
+            ChkCityHold.IsChecked = false;
+            ChkGladiatorArena.IsChecked = false;
+            ChkTournament.IsChecked = false;
+
+            SldLostStartCityDay.Value = 3;
+            SldCityHoldDays.Value = 6;
+            SldGladiatorDelay.Value = 30;
+            SldGladiatorCountDay.Value = 3;
+            SldTournamentRoundCount.Value = 3;
+            SldTournamentRoundDuration.Value = 3;
+            SldTournamentFirstAnnounceDay.Value = 7;
+            SldTournamentRoundInterval.Value = 7;
+            SldTournamentPointsToWin.Value = 2;
+
+            switch (victoryCondition)
+            {
+                case "win_condition_3":
+                    ChkLostStartCity.IsChecked = true;
+                    break;
+                case "win_condition_4":
+                    ChkLostStartHero.IsChecked = true;
+                    ChkGladiatorArena.IsChecked = true;
+                    break;
+                case "win_condition_5":
+                    ChkCityHold.IsChecked = true;
+                    break;
+                case "win_condition_6":
+                    ChkLostStartHero.IsChecked = true;
+                    ChkTournament.IsChecked = true;
+                    SldGladiatorDelay.Value = 21;
+                    SldGladiatorCountDay.Value = 8;
+                    break;
+            }
+        }
+
+        private void UpdateWinConditionDetailVisibility()
+        {
+            if (PnlLostStartCityDetails == null) return;
+
+            string selectedVictoryCondition = CmbVictory.SelectedIndex >= 0 && CmbVictory.SelectedIndex < KnownValues.VictoryConditionIds.Length
+                ? KnownValues.VictoryConditionIds[CmbVictory.SelectedIndex]
+                : "win_condition_1";
+
+            if (selectedVictoryCondition == "win_condition_3")
+                ChkLostStartCity.IsChecked = true;
+            if (selectedVictoryCondition == "win_condition_4")
+            {
+                ChkLostStartHero.IsChecked = true;
+                ChkGladiatorArena.IsChecked = true;
+            }
+            if (selectedVictoryCondition == "win_condition_5")
+                ChkCityHold.IsChecked = true;
+            if (selectedVictoryCondition == "win_condition_6")
+            {
+                ChkLostStartHero.IsChecked = true;
+                ChkTournament.IsChecked = true;
+            }
+
+            ChkLostStartCity.IsEnabled = selectedVictoryCondition != "win_condition_3";
+            ChkLostStartHero.IsEnabled = selectedVictoryCondition is not "win_condition_4" and not "win_condition_6";
+            ChkCityHold.IsEnabled = selectedVictoryCondition != "win_condition_5";
+            ChkGladiatorArena.IsEnabled = selectedVictoryCondition != "win_condition_4";
+            ChkTournament.IsEnabled = selectedVictoryCondition != "win_condition_6";
+
+            PnlLostStartCityDetails.Visibility = ChkLostStartCity.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+            PnlCityHoldDetails.Visibility = ChkCityHold.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+            PnlGladiatorDetails.Visibility = ChkGladiatorArena.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+            PnlTournamentDetails.Visibility = ChkTournament.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void UpdateExperimentalMapSizeWarningVisibility()
+        {
+            if (TxtExperimentalMapSizeWarning == null) return;
+            bool includeExperimental = ChkAdvancedMode?.IsChecked == true && ChkExperimentalMapSizes?.IsChecked == true;
+            TxtExperimentalMapSizeWarning.Visibility = includeExperimental ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private void UpdatePlayerCastleFactionVisibility()
@@ -354,7 +537,7 @@ namespace Olden_Era___Template_Editor
         private SettingsFile GatherSettings() => new()
         {
             TemplateName          = TxtTemplateName.Text.Trim(),
-            MapSize               = CmbMapSize.SelectedItem is string sizeStr && int.TryParse(sizeStr.Split('x')[0], out int ps) ? ps : 160,
+            MapSize               = SelectedMapSize(),
             PlayerCount           = (int)SldPlayers.Value,
             NeutralZoneCount      = (int)SldNeutral.Value,
             PlayerZoneCastles     = (int)SldPlayerCastles.Value,
@@ -368,6 +551,10 @@ namespace Olden_Era___Template_Editor
             NeutralHighCastleCount = (int)SldNeutralHighCastle.Value,
             MatchPlayerCastleFactions = ChkMatchPlayerCastleFactions.IsChecked == true,
             MinNeutralZonesBetweenPlayers = (int)SldMinNeutralBetweenPlayers.Value,
+            ExperimentalMapSizes  = ChkExperimentalMapSizes.IsChecked == true,
+            PlayerZoneSize        = ChkAdvancedMode.IsChecked == true ? SldPlayerZoneSize.Value : 1.0,
+            NeutralZoneSize       = ChkAdvancedMode.IsChecked == true ? SldNeutralZoneSize.Value : 1.0,
+            GuardRandomization    = SldGuardRandomization.Value / 100.0,
             HeroCountMin          = (int)SldHeroMin.Value,
             HeroCountMax          = (int)SldHeroMax.Value,
             HeroCountIncrement    = (int)SldHeroIncrement.Value,
@@ -380,18 +567,39 @@ namespace Olden_Era___Template_Editor
             StructureDensityPercent = (int)SldStructureDensity.Value,
             NeutralStackStrengthPercent = (int)SldNeutralStackStrength.Value,
             BorderGuardStrengthPercent = (int)SldBorderGuardStrength.Value,
+            VictoryCondition = CmbVictory.SelectedIndex >= 0 && CmbVictory.SelectedIndex < KnownValues.VictoryConditionIds.Length
+                ? KnownValues.VictoryConditionIds[CmbVictory.SelectedIndex]
+                : "win_condition_1",
+            FactionLawsExpPercent = (int)SldFactionLawsExp.Value,
+            AstrologyExpPercent = (int)SldAstrologyExp.Value,
+            LostStartCity = ChkLostStartCity.IsChecked == true,
+            LostStartCityDay = (int)SldLostStartCityDay.Value,
+            LostStartHero = ChkLostStartHero.IsChecked == true,
+            CityHold = ChkCityHold.IsChecked == true,
+            CityHoldDays = (int)SldCityHoldDays.Value,
+            GladiatorArena = ChkGladiatorArena.IsChecked == true,
+            GladiatorArenaDaysDelayStart = (int)SldGladiatorDelay.Value,
+            GladiatorArenaCountDay = (int)SldGladiatorCountDay.Value,
+            Tournament = ChkTournament.IsChecked == true,
+            TournamentRoundCount = (int)SldTournamentRoundCount.Value,
+            TournamentRoundDuration = (int)SldTournamentRoundDuration.Value,
+            TournamentFirstAnnounceDay = (int)SldTournamentFirstAnnounceDay.Value,
+            TournamentRoundInterval = (int)SldTournamentRoundInterval.Value,
+            TournamentPointsToWin = (int)SldTournamentPointsToWin.Value,
         };
 
         private void ApplySettings(SettingsFile s)
         {
             TxtTemplateName.Text    = s.TemplateName;
-            int sizeIdx = Array.IndexOf(KnownValues.MapSizes, s.MapSize);
-            if (sizeIdx >= 0) CmbMapSize.SelectedIndex = sizeIdx;
+            bool hasCustomZoneSizes = Math.Abs(s.PlayerZoneSize - 1.0) > 0.0001 || Math.Abs(s.NeutralZoneSize - 1.0) > 0.0001;
+            bool needsExperimentalMapSizes = s.ExperimentalMapSizes || KnownValues.IsExperimentalMapSize(s.MapSize);
+            ChkAdvancedMode.IsChecked = s.AdvancedMode || needsExperimentalMapSizes || hasCustomZoneSizes;
+            ChkExperimentalMapSizes.IsChecked = needsExperimentalMapSizes;
+            RefreshMapSizeOptions(s.MapSize);
             SldPlayers.Value        = s.PlayerCount;
             SldNeutral.Value        = s.NeutralZoneCount;
             SldPlayerCastles.Value  = s.PlayerZoneCastles;
             SldNeutralCastles.Value = s.NeutralZoneCastles;
-            ChkAdvancedMode.IsChecked = s.AdvancedMode;
             SldNeutralLowNoCastle.Value = s.NeutralLowNoCastleCount;
             SldNeutralLowCastle.Value = s.NeutralLowCastleCount;
             SldNeutralMediumNoCastle.Value = s.NeutralMediumNoCastleCount;
@@ -400,6 +608,9 @@ namespace Olden_Era___Template_Editor
             SldNeutralHighCastle.Value = s.NeutralHighCastleCount;
             ChkMatchPlayerCastleFactions.IsChecked = s.MatchPlayerCastleFactions;
             SldMinNeutralBetweenPlayers.Value = s.MinNeutralZonesBetweenPlayers;
+            SldPlayerZoneSize.Value = Math.Clamp(s.PlayerZoneSize, 0.1, 2.0);
+            SldNeutralZoneSize.Value = Math.Clamp(s.NeutralZoneSize, 0.1, 2.0);
+            SldGuardRandomization.Value = GuardRandomizationPercent(s.GuardRandomization);
             SldHeroMin.Value        = s.HeroCountMin;
             SldHeroMax.Value        = s.HeroCountMax;
             SldHeroIncrement.Value  = s.HeroCountIncrement;
@@ -413,10 +624,29 @@ namespace Olden_Era___Template_Editor
             SldStructureDensity.Value         = s.EffectiveStructureDensityPercent;
             SldNeutralStackStrength.Value     = s.NeutralStackStrengthPercent;
             SldBorderGuardStrength.Value      = s.BorderGuardStrengthPercent;
+            int victoryIdx = Array.IndexOf(KnownValues.VictoryConditionIds, s.VictoryCondition);
+            CmbVictory.SelectedIndex = victoryIdx >= 0 ? victoryIdx : 0;
+            SldFactionLawsExp.Value = Math.Clamp(s.FactionLawsExpPercent, 25, 200);
+            SldAstrologyExp.Value = Math.Clamp(s.AstrologyExpPercent, 25, 200);
+            ChkLostStartCity.IsChecked = s.LostStartCity;
+            SldLostStartCityDay.Value = Math.Clamp(s.LostStartCityDay, 1, 30);
+            ChkLostStartHero.IsChecked = s.LostStartHero;
+            ChkCityHold.IsChecked = s.CityHold;
+            SldCityHoldDays.Value = Math.Clamp(s.CityHoldDays, 1, 30);
+            ChkGladiatorArena.IsChecked = s.GladiatorArena;
+            SldGladiatorDelay.Value = Math.Clamp(s.GladiatorArenaDaysDelayStart, 1, 60);
+            SldGladiatorCountDay.Value = Math.Clamp(s.GladiatorArenaCountDay, 1, 30);
+            ChkTournament.IsChecked = s.Tournament;
+            SldTournamentRoundCount.Value = Math.Clamp(s.TournamentRoundCount, 1, 5);
+            SldTournamentRoundDuration.Value = Math.Clamp(s.TournamentRoundDuration, 1, 14);
+            SldTournamentFirstAnnounceDay.Value = Math.Clamp(s.TournamentFirstAnnounceDay, 1, 60);
+            SldTournamentRoundInterval.Value = Math.Clamp(s.TournamentRoundInterval, 1, 30);
+            SldTournamentPointsToWin.Value = Math.Clamp(s.TournamentPointsToWin, 1, 5);
             UpdateValueLabels();
             UpdateAdvancedModeVisibility();
             UpdatePlayerCastleFactionVisibility();
             UpdateRoadsHintVisibility();
+            UpdateWinConditionDetailVisibility();
         }
 
         private bool SaveToPath(string path)
@@ -510,8 +740,10 @@ namespace Olden_Era___Template_Editor
                 HeroCountMax = (int)SldHeroMax.Value,
                 HeroCountIncrement = (int)SldHeroIncrement.Value,
                 NeutralZoneCount = (int)SldNeutral.Value,
-                MapSize = CmbMapSize.SelectedItem is string sizeStr && int.TryParse(sizeStr.Split('x')[0], out int parsedSize) ? parsedSize : 160,
-                VictoryCondition = KnownValues.VictoryConditionIds[CmbVictory.SelectedIndex],
+                MapSize = SelectedMapSize(),
+                VictoryCondition = CmbVictory.SelectedIndex >= 0 && CmbVictory.SelectedIndex < KnownValues.VictoryConditionIds.Length
+                    ? KnownValues.VictoryConditionIds[CmbVictory.SelectedIndex]
+                    : "win_condition_1",
                 PlayerZoneCastles = (int)SldPlayerCastles.Value,
                 NeutralZoneCastles = (int)SldNeutralCastles.Value,
                 AdvancedMode = ChkAdvancedMode.IsChecked == true,
@@ -523,6 +755,9 @@ namespace Olden_Era___Template_Editor
                 NeutralHighCastleCount = (int)SldNeutralHighCastle.Value,
                 MatchPlayerCastleFactions = ChkMatchPlayerCastleFactions.IsChecked == true,
                 MinNeutralZonesBetweenPlayers = ChkAdvancedMode.IsChecked == true ? (int)SldMinNeutralBetweenPlayers.Value : 0,
+                PlayerZoneSize = ChkAdvancedMode.IsChecked == true ? SldPlayerZoneSize.Value : 1.0,
+                NeutralZoneSize = ChkAdvancedMode.IsChecked == true ? SldNeutralZoneSize.Value : 1.0,
+                GuardRandomization = ChkAdvancedMode.IsChecked == true ? SldGuardRandomization.Value / 100.0 : 0.05,
                 NoDirectPlayerConnections = ChkNoDirectPlayerConn.IsChecked == true,
                 RandomPortals = ChkRandomPortals.IsChecked == true,
                 SpawnRemoteFootholds = ChkSpawnFootholds.IsChecked == true,
@@ -531,7 +766,23 @@ namespace Olden_Era___Template_Editor
                 ResourceDensityPercent = (int)SldResourceDensity.Value,
                 StructureDensityPercent = (int)SldStructureDensity.Value,
                 NeutralStackStrengthPercent = (int)SldNeutralStackStrength.Value,
-                BorderGuardStrengthPercent = (int)SldBorderGuardStrength.Value
+                BorderGuardStrengthPercent = (int)SldBorderGuardStrength.Value,
+                FactionLawsExpPercent = ChkAdvancedMode.IsChecked == true ? (int)SldFactionLawsExp.Value : 100,
+                AstrologyExpPercent = ChkAdvancedMode.IsChecked == true ? (int)SldAstrologyExp.Value : 100,
+                LostStartCity = ChkAdvancedMode.IsChecked == true && ChkLostStartCity.IsChecked == true,
+                LostStartCityDay = (int)SldLostStartCityDay.Value,
+                LostStartHero = ChkAdvancedMode.IsChecked == true && ChkLostStartHero.IsChecked == true,
+                CityHold = ChkAdvancedMode.IsChecked == true && ChkCityHold.IsChecked == true,
+                CityHoldDays = (int)SldCityHoldDays.Value,
+                GladiatorArena = ChkAdvancedMode.IsChecked == true && ChkGladiatorArena.IsChecked == true,
+                GladiatorArenaDaysDelayStart = (int)SldGladiatorDelay.Value,
+                GladiatorArenaCountDay = (int)SldGladiatorCountDay.Value,
+                Tournament = ChkAdvancedMode.IsChecked == true && ChkTournament.IsChecked == true,
+                TournamentRoundCount = (int)SldTournamentRoundCount.Value,
+                TournamentRoundDuration = (int)SldTournamentRoundDuration.Value,
+                TournamentFirstAnnounceDay = (int)SldTournamentFirstAnnounceDay.Value,
+                TournamentRoundInterval = (int)SldTournamentRoundInterval.Value,
+                TournamentPointsToWin = (int)SldTournamentPointsToWin.Value
             };
 
             var template = TemplateGenerator.Generate(settings);

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -16,6 +16,8 @@ namespace Olden_Era___Template_Editor
     {
         private const string GitHubApiLatestRelease = "https://api.github.com/repos/KhanDevelopsGames/Olden-Era---Template-Generator/releases/latest";
         private const string GitHubReleasesPage     = "https://github.com/KhanDevelopsGames/Olden-Era---Template-Generator/releases";
+        private const int SimpleModeMaxZones = 16;
+        private const int AdvancedModeMaxZones = 32;
 
         private static readonly HttpClient Http = new();
 
@@ -58,6 +60,10 @@ namespace Olden_Era___Template_Editor
             CmbVictory.SelectedIndex = 0; // Classic (win_condition_1)
             CmbTopology.ItemsSource = TopologyOptions.Select(t => t.Label).ToList();
             CmbTopology.SelectedIndex = 0; // Random is first
+            UpdateValueLabels();
+            UpdateAdvancedModeVisibility();
+            UpdatePlayerCastleFactionVisibility();
+            UpdateRoadsHintVisibility();
 
             // Fire-and-forget background update check — never blocks the UI.
             _ = CheckForUpdateAsync(version);
@@ -147,6 +153,16 @@ namespace Olden_Era___Template_Editor
         {
             if (!IsInitialized) return;
 
+            UpdateValueLabels();
+            UpdatePlayerCastleFactionVisibility();
+            UpdateAdvancedModeVisibility();
+            UpdateRoadsHintVisibility();
+            MarkDirty();
+            Validate();
+        }
+
+        private void UpdateValueLabels()
+        {
             TxtPlayers.Text = ((int)SldPlayers.Value).ToString();
             TxtHeroMin.Text = ((int)SldHeroMin.Value).ToString();
             TxtHeroMax.Text = ((int)SldHeroMax.Value).ToString();
@@ -158,10 +174,13 @@ namespace Olden_Era___Template_Editor
             TxtStructureDensity.Text = $"{(int)SldStructureDensity.Value}%";
             TxtNeutralStackStrength.Text = $"{(int)SldNeutralStackStrength.Value}%";
             TxtBorderGuardStrength.Text = $"{(int)SldBorderGuardStrength.Value}%";
-
-            UpdateRoadsHintVisibility();
-            MarkDirty();
-            Validate();
+            TxtNeutralLowNoCastle.Text = ((int)SldNeutralLowNoCastle.Value).ToString();
+            TxtNeutralLowCastle.Text = ((int)SldNeutralLowCastle.Value).ToString();
+            TxtNeutralMediumNoCastle.Text = ((int)SldNeutralMediumNoCastle.Value).ToString();
+            TxtNeutralMediumCastle.Text = ((int)SldNeutralMediumCastle.Value).ToString();
+            TxtNeutralHighNoCastle.Text = ((int)SldNeutralHighNoCastle.Value).ToString();
+            TxtNeutralHighCastle.Text = ((int)SldNeutralHighCastle.Value).ToString();
+            TxtMinNeutralBetweenPlayers.Text = ((int)SldMinNeutralBetweenPlayers.Value).ToString();
         }
 
         private bool Validate()
@@ -169,7 +188,7 @@ namespace Olden_Era___Template_Editor
             int heroMin = (int)SldHeroMin.Value;
             int heroMax = (int)SldHeroMax.Value;
             int players = (int)SldPlayers.Value;
-            int neutral = (int)SldNeutral.Value;
+            int neutral = TotalNeutralZonesFromUi();
 
             if (heroMin > heroMax)
             {
@@ -178,9 +197,10 @@ namespace Olden_Era___Template_Editor
                 return false;
             }
 
-            if (players + neutral > 16)
+            int maxZones = ChkAdvancedMode.IsChecked == true ? AdvancedModeMaxZones : SimpleModeMaxZones;
+            if (players + neutral > maxZones)
             {
-                TxtValidation.Text = "Total zones (players + neutral) cannot exceed 16.";
+                TxtValidation.Text = $"Total zones (players + neutral) cannot exceed {maxZones}.";
                 BtnGenerate.IsEnabled = false;
                 return false;
             }
@@ -197,10 +217,39 @@ namespace Olden_Era___Template_Editor
             if (players + neutral > 4 && CmbMapSize.SelectedItem is string selStr && int.TryParse(selStr.Split('x')[0], out int selectedSize) && selectedSize < 128)
                 warnings.Add("⚠️ Using a small map with many zones may freeze the game while loading the map. Consider using a larger map size.");
 
+            int minNeutralBetweenPlayers = (int)SldMinNeutralBetweenPlayers.Value;
+            if (ChkAdvancedMode.IsChecked == true && minNeutralBetweenPlayers > 0)
+            {
+                var topology = CmbTopology.SelectedIndex >= 0 ? TopologyOptions[CmbTopology.SelectedIndex].Topology : MapTopology.Default;
+                var separationSettings = new GeneratorSettings
+                {
+                    PlayerCount = players,
+                    Topology = topology,
+                    RandomPortals = ChkRandomPortals.IsChecked == true,
+                    MinNeutralZonesBetweenPlayers = minNeutralBetweenPlayers
+                };
+
+                if (!TemplateGenerator.CanHonorNeutralSeparation(separationSettings, neutral))
+                    warnings.Add("Minimum neutral separation cannot be guaranteed with the current layout, neutral zone total, or portal setting; generation will ignore that option.");
+            }
+
             TxtValidation.Text = string.Join("\n\n", warnings);
 
             BtnGenerate.IsEnabled = true;
             return true;
+        }
+
+        private int TotalNeutralZonesFromUi()
+        {
+            if (ChkAdvancedMode.IsChecked != true)
+                return (int)SldNeutral.Value;
+
+            return (int)SldNeutralLowNoCastle.Value
+                + (int)SldNeutralLowCastle.Value
+                + (int)SldNeutralMediumNoCastle.Value
+                + (int)SldNeutralMediumCastle.Value
+                + (int)SldNeutralHighNoCastle.Value
+                + (int)SldNeutralHighCastle.Value;
         }
 
         private void CmbTopology_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -216,6 +265,7 @@ namespace Olden_Era___Template_Editor
             ChkNoDirectPlayerConn.Visibility = isolateApplicable ? Visibility.Visible : Visibility.Collapsed;
             if (!isolateApplicable) ChkNoDirectPlayerConn.IsChecked = false;
             UpdateIsolateDescVisibility();
+            UpdateAdvancedModeVisibility();
 
             MarkDirty();
             Validate();
@@ -233,8 +283,54 @@ namespace Olden_Era___Template_Editor
             if (!IsInitialized) return;
             UpdateIsolateDescVisibility();
             UpdateRoadsHintVisibility();
+            UpdatePlayerCastleFactionVisibility();
             MarkDirty();
             Validate();
+        }
+
+        private void ChkAdvancedMode_Changed(object sender, RoutedEventArgs e)
+        {
+            if (!IsInitialized) return;
+            if (ChkAdvancedMode.IsChecked == true && TotalAdvancedNeutralZonesFromSliders() == 0 && (int)SldNeutral.Value > 0)
+            {
+                if ((int)SldNeutralCastles.Value > 0)
+                    SldNeutralMediumCastle.Value = SldNeutral.Value;
+                else
+                    SldNeutralMediumNoCastle.Value = SldNeutral.Value;
+            }
+
+            UpdateAdvancedModeVisibility();
+            UpdateValueLabels();
+            UpdateRoadsHintVisibility();
+            MarkDirty();
+            Validate();
+        }
+
+        private int TotalAdvancedNeutralZonesFromSliders() =>
+            (int)SldNeutralLowNoCastle.Value
+            + (int)SldNeutralLowCastle.Value
+            + (int)SldNeutralMediumNoCastle.Value
+            + (int)SldNeutralMediumCastle.Value
+            + (int)SldNeutralHighNoCastle.Value
+            + (int)SldNeutralHighCastle.Value;
+
+        private void UpdateAdvancedModeVisibility()
+        {
+            if (PnlAdvancedNeutralZones == null) return;
+            bool advanced = ChkAdvancedMode.IsChecked == true;
+            PnlAdvancedNeutralZones.Visibility = advanced ? Visibility.Visible : Visibility.Collapsed;
+            PnlAdvancedSeparation.Visibility = advanced ? Visibility.Visible : Visibility.Collapsed;
+            PnlSimpleNeutralCountLabel.Visibility = advanced ? Visibility.Collapsed : Visibility.Visible;
+            SldNeutral.Visibility = advanced ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void UpdatePlayerCastleFactionVisibility()
+        {
+            if (PnlPlayerCastleFactionOption == null || SldPlayerCastles == null) return;
+            bool hasExtraCastles = (int)SldPlayerCastles.Value > 1;
+            PnlPlayerCastleFactionOption.Visibility = hasExtraCastles ? Visibility.Visible : Visibility.Collapsed;
+            if (!hasExtraCastles)
+                ChkMatchPlayerCastleFactions.IsChecked = false;
         }
 
         private void UpdateIsolateDescVisibility()
@@ -263,6 +359,15 @@ namespace Olden_Era___Template_Editor
             NeutralZoneCount      = (int)SldNeutral.Value,
             PlayerZoneCastles     = (int)SldPlayerCastles.Value,
             NeutralZoneCastles    = (int)SldNeutralCastles.Value,
+            AdvancedMode          = ChkAdvancedMode.IsChecked == true,
+            NeutralLowNoCastleCount = (int)SldNeutralLowNoCastle.Value,
+            NeutralLowCastleCount = (int)SldNeutralLowCastle.Value,
+            NeutralMediumNoCastleCount = (int)SldNeutralMediumNoCastle.Value,
+            NeutralMediumCastleCount = (int)SldNeutralMediumCastle.Value,
+            NeutralHighNoCastleCount = (int)SldNeutralHighNoCastle.Value,
+            NeutralHighCastleCount = (int)SldNeutralHighCastle.Value,
+            MatchPlayerCastleFactions = ChkMatchPlayerCastleFactions.IsChecked == true,
+            MinNeutralZonesBetweenPlayers = (int)SldMinNeutralBetweenPlayers.Value,
             HeroCountMin          = (int)SldHeroMin.Value,
             HeroCountMax          = (int)SldHeroMax.Value,
             HeroCountIncrement    = (int)SldHeroIncrement.Value,
@@ -286,6 +391,15 @@ namespace Olden_Era___Template_Editor
             SldNeutral.Value        = s.NeutralZoneCount;
             SldPlayerCastles.Value  = s.PlayerZoneCastles;
             SldNeutralCastles.Value = s.NeutralZoneCastles;
+            ChkAdvancedMode.IsChecked = s.AdvancedMode;
+            SldNeutralLowNoCastle.Value = s.NeutralLowNoCastleCount;
+            SldNeutralLowCastle.Value = s.NeutralLowCastleCount;
+            SldNeutralMediumNoCastle.Value = s.NeutralMediumNoCastleCount;
+            SldNeutralMediumCastle.Value = s.NeutralMediumCastleCount;
+            SldNeutralHighNoCastle.Value = s.NeutralHighNoCastleCount;
+            SldNeutralHighCastle.Value = s.NeutralHighCastleCount;
+            ChkMatchPlayerCastleFactions.IsChecked = s.MatchPlayerCastleFactions;
+            SldMinNeutralBetweenPlayers.Value = s.MinNeutralZonesBetweenPlayers;
             SldHeroMin.Value        = s.HeroCountMin;
             SldHeroMax.Value        = s.HeroCountMax;
             SldHeroIncrement.Value  = s.HeroCountIncrement;
@@ -299,6 +413,10 @@ namespace Olden_Era___Template_Editor
             SldStructureDensity.Value         = s.EffectiveStructureDensityPercent;
             SldNeutralStackStrength.Value     = s.NeutralStackStrengthPercent;
             SldBorderGuardStrength.Value      = s.BorderGuardStrengthPercent;
+            UpdateValueLabels();
+            UpdateAdvancedModeVisibility();
+            UpdatePlayerCastleFactionVisibility();
+            UpdateRoadsHintVisibility();
         }
 
         private bool SaveToPath(string path)
@@ -396,6 +514,15 @@ namespace Olden_Era___Template_Editor
                 VictoryCondition = KnownValues.VictoryConditionIds[CmbVictory.SelectedIndex],
                 PlayerZoneCastles = (int)SldPlayerCastles.Value,
                 NeutralZoneCastles = (int)SldNeutralCastles.Value,
+                AdvancedMode = ChkAdvancedMode.IsChecked == true,
+                NeutralLowNoCastleCount = (int)SldNeutralLowNoCastle.Value,
+                NeutralLowCastleCount = (int)SldNeutralLowCastle.Value,
+                NeutralMediumNoCastleCount = (int)SldNeutralMediumNoCastle.Value,
+                NeutralMediumCastleCount = (int)SldNeutralMediumCastle.Value,
+                NeutralHighNoCastleCount = (int)SldNeutralHighNoCastle.Value,
+                NeutralHighCastleCount = (int)SldNeutralHighCastle.Value,
+                MatchPlayerCastleFactions = ChkMatchPlayerCastleFactions.IsChecked == true,
+                MinNeutralZonesBetweenPlayers = ChkAdvancedMode.IsChecked == true ? (int)SldMinNeutralBetweenPlayers.Value : 0,
                 NoDirectPlayerConnections = ChkNoDirectPlayerConn.IsChecked == true,
                 RandomPortals = ChkRandomPortals.IsChecked == true,
                 SpawnRemoteFootholds = ChkSpawnFootholds.IsChecked == true,
@@ -426,7 +553,22 @@ namespace Olden_Era___Template_Editor
             string json = JsonSerializer.Serialize(template, JsonOptions);
             File.WriteAllText(dlg.FileName, json);
 
+            string previewPath = TemplatePreviewPngWriter.GetSidecarPath(dlg.FileName);
+            string? previewError = null;
+            try
+            {
+                TemplatePreviewPngWriter.Save(template, previewPath);
+            }
+            catch (Exception ex)
+            {
+                previewError = ex.Message;
+            }
+
             string savedMsg = $"Template successfully saved to:\n\n{dlg.FileName}";
+            if (previewError == null)
+                savedMsg += $"\n\nPreview PNG saved to:\n\n{previewPath}";
+            else
+                savedMsg += $"\n\nTemplate saved, but the preview PNG could not be created:\n{previewError}";
             if (gameTemplatesPath == null)
                 savedMsg += "\n\n\n💡 Tip: Templates must be placed in:\n<Olden Era install folder>\\HeroesOldenEra_Data\\StreamingAssets\\map_templates";
 

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -154,7 +154,10 @@ namespace Olden_Era___Template_Editor
             TxtNeutral.Text = ((int)SldNeutral.Value).ToString();
             TxtPlayerCastles.Text = ((int)SldPlayerCastles.Value).ToString();
             TxtNeutralCastles.Text = ((int)SldNeutralCastles.Value).ToString();
-            TxtContentDensity.Text = $"{(int)SldContentDensity.Value}%";
+            TxtResourceDensity.Text = $"{(int)SldResourceDensity.Value}%";
+            TxtStructureDensity.Text = $"{(int)SldStructureDensity.Value}%";
+            TxtNeutralStackStrength.Text = $"{(int)SldNeutralStackStrength.Value}%";
+            TxtBorderGuardStrength.Text = $"{(int)SldBorderGuardStrength.Value}%";
 
             UpdateRoadsHintVisibility();
             MarkDirty();
@@ -268,7 +271,10 @@ namespace Olden_Era___Template_Editor
             SpawnRemoteFootholds  = ChkSpawnFootholds.IsChecked == true,
             GenerateRoads         = ChkGenerateRoads.IsChecked == true,
             NoDirectPlayerConn    = ChkNoDirectPlayerConn.IsChecked == true,
-            ContentDensityPercent = (int)SldContentDensity.Value,
+            ResourceDensityPercent = (int)SldResourceDensity.Value,
+            StructureDensityPercent = (int)SldStructureDensity.Value,
+            NeutralStackStrengthPercent = (int)SldNeutralStackStrength.Value,
+            BorderGuardStrengthPercent = (int)SldBorderGuardStrength.Value,
         };
 
         private void ApplySettings(SettingsFile s)
@@ -289,7 +295,10 @@ namespace Olden_Era___Template_Editor
             ChkSpawnFootholds.IsChecked       = s.SpawnRemoteFootholds;
             ChkGenerateRoads.IsChecked        = s.GenerateRoads;
             ChkNoDirectPlayerConn.IsChecked   = s.NoDirectPlayerConn;
-            SldContentDensity.Value           = s.ContentDensityPercent;
+            SldResourceDensity.Value          = s.EffectiveResourceDensityPercent;
+            SldStructureDensity.Value         = s.EffectiveStructureDensityPercent;
+            SldNeutralStackStrength.Value     = s.NeutralStackStrengthPercent;
+            SldBorderGuardStrength.Value      = s.BorderGuardStrengthPercent;
         }
 
         private bool SaveToPath(string path)
@@ -392,7 +401,10 @@ namespace Olden_Era___Template_Editor
                 SpawnRemoteFootholds = ChkSpawnFootholds.IsChecked == true,
                 GenerateRoads = ChkGenerateRoads.IsChecked == true,
                 Topology = CmbTopology.SelectedIndex >= 0 ? TopologyOptions[CmbTopology.SelectedIndex].Topology : MapTopology.Default,
-                ContentDensityPercent = (int)SldContentDensity.Value
+                ResourceDensityPercent = (int)SldResourceDensity.Value,
+                StructureDensityPercent = (int)SldStructureDensity.Value,
+                NeutralStackStrengthPercent = (int)SldNeutralStackStrength.Value,
+                BorderGuardStrengthPercent = (int)SldBorderGuardStrength.Value
             };
 
             var template = TemplateGenerator.Generate(settings);

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -64,6 +64,7 @@ namespace Olden_Era___Template_Editor
             UpdateAdvancedModeVisibility();
             UpdatePlayerCastleFactionVisibility();
             UpdateRoadsHintVisibility();
+            UpdateBalancedZonePlacementDescVisibility();
 
             // Fire-and-forget background update check — never blocks the UI.
             _ = CheckForUpdateAsync(version);
@@ -347,6 +348,7 @@ namespace Olden_Era___Template_Editor
             if (!IsInitialized) return;
             UpdateIsolateDescVisibility();
             UpdateRoadsHintVisibility();
+            UpdateBalancedZonePlacementDescVisibility();
             UpdatePlayerCastleFactionVisibility();
             UpdateWinConditionDetailVisibility();
             MarkDirty();
@@ -532,6 +534,14 @@ namespace Olden_Era___Template_Editor
                 : Visibility.Collapsed;
         }
 
+        private void UpdateBalancedZonePlacementDescVisibility()
+        {
+            if (TxtBalancedZonePlacementDesc == null || ChkBalancedZonePlacement == null) return;
+            TxtBalancedZonePlacementDesc.Visibility = ChkBalancedZonePlacement.IsChecked == true
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        }
+
         // ── Settings persistence ───────────────────────────────────────────────
 
         private SettingsFile GatherSettings() => new()
@@ -551,6 +561,7 @@ namespace Olden_Era___Template_Editor
             NeutralHighCastleCount = (int)SldNeutralHighCastle.Value,
             MatchPlayerCastleFactions = ChkMatchPlayerCastleFactions.IsChecked == true,
             MinNeutralZonesBetweenPlayers = (int)SldMinNeutralBetweenPlayers.Value,
+            ExperimentalBalancedZonePlacement = ChkBalancedZonePlacement.IsChecked == true,
             ExperimentalMapSizes  = ChkExperimentalMapSizes.IsChecked == true,
             PlayerZoneSize        = ChkAdvancedMode.IsChecked == true ? SldPlayerZoneSize.Value : 1.0,
             NeutralZoneSize       = ChkAdvancedMode.IsChecked == true ? SldNeutralZoneSize.Value : 1.0,
@@ -608,6 +619,7 @@ namespace Olden_Era___Template_Editor
             SldNeutralHighCastle.Value = s.NeutralHighCastleCount;
             ChkMatchPlayerCastleFactions.IsChecked = s.MatchPlayerCastleFactions;
             SldMinNeutralBetweenPlayers.Value = s.MinNeutralZonesBetweenPlayers;
+            ChkBalancedZonePlacement.IsChecked = s.ExperimentalBalancedZonePlacement;
             SldPlayerZoneSize.Value = Math.Clamp(s.PlayerZoneSize, 0.1, 2.0);
             SldNeutralZoneSize.Value = Math.Clamp(s.NeutralZoneSize, 0.1, 2.0);
             SldGuardRandomization.Value = GuardRandomizationPercent(s.GuardRandomization);
@@ -646,6 +658,7 @@ namespace Olden_Era___Template_Editor
             UpdateAdvancedModeVisibility();
             UpdatePlayerCastleFactionVisibility();
             UpdateRoadsHintVisibility();
+            UpdateBalancedZonePlacementDescVisibility();
             UpdateWinConditionDetailVisibility();
         }
 
@@ -755,6 +768,7 @@ namespace Olden_Era___Template_Editor
                 NeutralHighCastleCount = (int)SldNeutralHighCastle.Value,
                 MatchPlayerCastleFactions = ChkMatchPlayerCastleFactions.IsChecked == true,
                 MinNeutralZonesBetweenPlayers = ChkAdvancedMode.IsChecked == true ? (int)SldMinNeutralBetweenPlayers.Value : 0,
+                ExperimentalBalancedZonePlacement = ChkBalancedZonePlacement.IsChecked == true,
                 PlayerZoneSize = ChkAdvancedMode.IsChecked == true ? SldPlayerZoneSize.Value : 1.0,
                 NeutralZoneSize = ChkAdvancedMode.IsChecked == true ? SldNeutralZoneSize.Value : 1.0,
                 GuardRandomization = ChkAdvancedMode.IsChecked == true ? SldGuardRandomization.Value / 100.0 : 0.05,

--- a/Olden Era - Template Editor/Models/GameRules.cs
+++ b/Olden Era - Template Editor/Models/GameRules.cs
@@ -103,5 +103,20 @@ namespace OldenEraTemplateEditor.Models
 
         [JsonPropertyName("championSelectRule")]
         public string? ChampionSelectRule { get; set; }
+
+        [JsonPropertyName("tournament")]
+        public bool? Tournament { get; set; }
+
+        [JsonPropertyName("tournamentDays")]
+        public List<int>? TournamentDays { get; set; }
+
+        [JsonPropertyName("tournamentAnnounceDays")]
+        public List<int>? TournamentAnnounceDays { get; set; }
+
+        [JsonPropertyName("tournamentPointsToWin")]
+        public int? TournamentPointsToWin { get; set; }
+
+        [JsonPropertyName("tournamentSaveArmy")]
+        public bool? TournamentSaveArmy { get; set; }
     }
 }

--- a/Olden Era - Template Editor/Models/GeneratorSettings.cs
+++ b/Olden Era - Template Editor/Models/GeneratorSettings.cs
@@ -13,6 +13,15 @@ namespace Olden_Era___Template_Editor.Models
         public string VictoryCondition { get; set; } = "win_condition_1";
         public int PlayerZoneCastles { get; set; } = 1;
         public int NeutralZoneCastles { get; set; } = 1;
+        public bool AdvancedMode { get; set; } = false;
+        public int NeutralLowNoCastleCount { get; set; } = 0;
+        public int NeutralLowCastleCount { get; set; } = 0;
+        public int NeutralMediumNoCastleCount { get; set; } = 0;
+        public int NeutralMediumCastleCount { get; set; } = 0;
+        public int NeutralHighNoCastleCount { get; set; } = 0;
+        public int NeutralHighCastleCount { get; set; } = 0;
+        public bool MatchPlayerCastleFactions { get; set; } = false;
+        public int MinNeutralZonesBetweenPlayers { get; set; } = 0;
         public bool NoDirectPlayerConnections { get; set; } = false;
         public bool RandomPortals { get; set; } = false;
         public bool SpawnRemoteFootholds { get; set; } = true;
@@ -22,5 +31,12 @@ namespace Olden_Era___Template_Editor.Models
         public int StructureDensityPercent { get; set; } = 100;
         public int NeutralStackStrengthPercent { get; set; } = 100;
         public int BorderGuardStrengthPercent { get; set; } = 100;
+    }
+
+    public enum NeutralZoneQuality
+    {
+        Low,
+        Medium,
+        High
     }
 }

--- a/Olden Era - Template Editor/Models/GeneratorSettings.cs
+++ b/Olden Era - Template Editor/Models/GeneratorSettings.cs
@@ -18,6 +18,9 @@ namespace Olden_Era___Template_Editor.Models
         public bool SpawnRemoteFootholds { get; set; } = true;
         public bool GenerateRoads { get; set; } = true;
         public MapTopology Topology { get; set; } = MapTopology.Random;
-        public int ContentDensityPercent { get; set; } = 100;
+        public int ResourceDensityPercent { get; set; } = 100;
+        public int StructureDensityPercent { get; set; } = 100;
+        public int NeutralStackStrengthPercent { get; set; } = 100;
+        public int BorderGuardStrengthPercent { get; set; } = 100;
     }
 }

--- a/Olden Era - Template Editor/Models/GeneratorSettings.cs
+++ b/Olden Era - Template Editor/Models/GeneratorSettings.cs
@@ -22,6 +22,7 @@ namespace Olden_Era___Template_Editor.Models
         public int NeutralHighCastleCount { get; set; } = 0;
         public bool MatchPlayerCastleFactions { get; set; } = false;
         public int MinNeutralZonesBetweenPlayers { get; set; } = 0;
+        public bool ExperimentalBalancedZonePlacement { get; set; } = false;
         public double PlayerZoneSize { get; set; } = 1.0;
         public double NeutralZoneSize { get; set; } = 1.0;
         public double GuardRandomization { get; set; } = 0.05;

--- a/Olden Era - Template Editor/Models/GeneratorSettings.cs
+++ b/Olden Era - Template Editor/Models/GeneratorSettings.cs
@@ -22,6 +22,9 @@ namespace Olden_Era___Template_Editor.Models
         public int NeutralHighCastleCount { get; set; } = 0;
         public bool MatchPlayerCastleFactions { get; set; } = false;
         public int MinNeutralZonesBetweenPlayers { get; set; } = 0;
+        public double PlayerZoneSize { get; set; } = 1.0;
+        public double NeutralZoneSize { get; set; } = 1.0;
+        public double GuardRandomization { get; set; } = 0.05;
         public bool NoDirectPlayerConnections { get; set; } = false;
         public bool RandomPortals { get; set; } = false;
         public bool SpawnRemoteFootholds { get; set; } = true;
@@ -31,6 +34,22 @@ namespace Olden_Era___Template_Editor.Models
         public int StructureDensityPercent { get; set; } = 100;
         public int NeutralStackStrengthPercent { get; set; } = 100;
         public int BorderGuardStrengthPercent { get; set; } = 100;
+        public int FactionLawsExpPercent { get; set; } = 100;
+        public int AstrologyExpPercent { get; set; } = 100;
+        public bool LostStartCity { get; set; } = false;
+        public int LostStartCityDay { get; set; } = 3;
+        public bool LostStartHero { get; set; } = false;
+        public bool CityHold { get; set; } = false;
+        public int CityHoldDays { get; set; } = 6;
+        public bool GladiatorArena { get; set; } = false;
+        public int GladiatorArenaDaysDelayStart { get; set; } = 30;
+        public int GladiatorArenaCountDay { get; set; } = 3;
+        public bool Tournament { get; set; } = false;
+        public int TournamentRoundCount { get; set; } = 3;
+        public int TournamentRoundDuration { get; set; } = 3;
+        public int TournamentFirstAnnounceDay { get; set; } = 7;
+        public int TournamentRoundInterval { get; set; } = 7;
+        public int TournamentPointsToWin { get; set; } = 2;
     }
 
     public enum NeutralZoneQuality

--- a/Olden Era - Template Editor/Models/KnownValues.cs
+++ b/Olden Era - Template Editor/Models/KnownValues.cs
@@ -14,11 +14,25 @@ namespace OldenEraTemplateEditor.Models
             "SingleHero",
         ];
 
-        /// <summary>Map sizes (sizeX = sizeZ) found across all example templates.</summary>
+        /// <summary>Official/example-backed map sizes (sizeX = sizeZ).</summary>
         public static readonly int[] MapSizes =
         [
             64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 240
         ];
+
+        /// <summary>Experimental map sizes above the largest official/example-backed size.</summary>
+        public static readonly int[] ExperimentalMapSizes =
+        [
+            256, 272, 288, 304, 320, 336, 352, 368, 384,
+            400, 416, 432, 448, 464, 480, 496, 512
+        ];
+
+        public static readonly int[] AllMapSizes = [.. MapSizes, .. ExperimentalMapSizes];
+
+        public static int MaxOfficialMapSize => MapSizes[^1];
+
+        public static bool IsExperimentalMapSize(int size) =>
+            Array.IndexOf(ExperimentalMapSizes, size) >= 0;
 
         /// <summary>
         /// Human-readable labels for each displayWinCondition ID.
@@ -27,9 +41,10 @@ namespace OldenEraTemplateEditor.Models
         public static readonly string[] VictoryConditionLabels =
         [
             "Standard (Classic Kill)",
-            "Lost City / Lost Hero",
-            "Hold City for N Days",
+            "Lost Starting City",
             "Gladiator Arena",
+            "Hold City for N Days",
+            "Tournament",
         ];
 
         /// <summary>
@@ -39,6 +54,7 @@ namespace OldenEraTemplateEditor.Models
         [
             "win_condition_1",
             "win_condition_3",
+            "win_condition_4",
             "win_condition_5",
             "win_condition_6",
         ];

--- a/Olden Era - Template Editor/Models/SettingsFile.cs
+++ b/Olden Era - Template Editor/Models/SettingsFile.cs
@@ -23,6 +23,7 @@ namespace Olden_Era___Template_Editor.Models
         [JsonPropertyName("neutralHighCastle")]     public int NeutralHighCastleCount     { get; set; } = 0;
         [JsonPropertyName("matchPlayerCastleFactions")] public bool MatchPlayerCastleFactions { get; set; } = false;
         [JsonPropertyName("minNeutralZonesBetweenPlayers")] public int MinNeutralZonesBetweenPlayers { get; set; } = 0;
+        [JsonPropertyName("experimentalBalancedZonePlacement")] public bool ExperimentalBalancedZonePlacement { get; set; } = false;
         [JsonPropertyName("experimentalMapSizes")] public bool ExperimentalMapSizes { get; set; } = false;
         [JsonPropertyName("playerZoneSize")]  public double  PlayerZoneSize       { get; set; } = 1.0;
         [JsonPropertyName("neutralZoneSize")] public double  NeutralZoneSize      { get; set; } = 1.0;

--- a/Olden Era - Template Editor/Models/SettingsFile.cs
+++ b/Olden Era - Template Editor/Models/SettingsFile.cs
@@ -22,6 +22,15 @@ namespace Olden_Era___Template_Editor.Models
         [JsonPropertyName("spawnFootholds")]    public bool    SpawnRemoteFootholds   { get; set; } = true;
         [JsonPropertyName("generateRoads")]     public bool    GenerateRoads          { get; set; } = true;
         [JsonPropertyName("isolateplayers")]    public bool    NoDirectPlayerConn     { get; set; } = false;
-        [JsonPropertyName("contentDensity")]    public int     ContentDensityPercent  { get; set; } = 100;
+        [JsonPropertyName("resourceDensity")]   public int?    ResourceDensityPercent       { get; set; }
+        [JsonPropertyName("structureDensity")]  public int?    StructureDensityPercent      { get; set; }
+        [JsonPropertyName("neutralStackStrength")] public int  NeutralStackStrengthPercent  { get; set; } = 100;
+        [JsonPropertyName("borderGuardStrength")]  public int  BorderGuardStrengthPercent   { get; set; } = 100;
+
+        // Legacy setting from v0.2 and earlier; when present, it seeds both split density sliders.
+        [JsonPropertyName("contentDensity")]    public int?    ContentDensityPercent        { get; set; }
+
+        [JsonIgnore] public int EffectiveResourceDensityPercent  => ResourceDensityPercent  ?? ContentDensityPercent ?? 100;
+        [JsonIgnore] public int EffectiveStructureDensityPercent => StructureDensityPercent ?? ContentDensityPercent ?? 100;
     }
 }

--- a/Olden Era - Template Editor/Models/SettingsFile.cs
+++ b/Olden Era - Template Editor/Models/SettingsFile.cs
@@ -14,6 +14,15 @@ namespace Olden_Era___Template_Editor.Models
         [JsonPropertyName("neutralZoneCount")]  public int     NeutralZoneCount       { get; set; } = 0;
         [JsonPropertyName("playerCastles")]     public int     PlayerZoneCastles      { get; set; } = 1;
         [JsonPropertyName("neutralCastles")]    public int     NeutralZoneCastles     { get; set; } = 1;
+        [JsonPropertyName("advancedMode")]      public bool    AdvancedMode           { get; set; } = false;
+        [JsonPropertyName("neutralLowNoCastle")]    public int NeutralLowNoCastleCount    { get; set; } = 0;
+        [JsonPropertyName("neutralLowCastle")]      public int NeutralLowCastleCount      { get; set; } = 0;
+        [JsonPropertyName("neutralMediumNoCastle")] public int NeutralMediumNoCastleCount { get; set; } = 0;
+        [JsonPropertyName("neutralMediumCastle")]   public int NeutralMediumCastleCount   { get; set; } = 0;
+        [JsonPropertyName("neutralHighNoCastle")]   public int NeutralHighNoCastleCount   { get; set; } = 0;
+        [JsonPropertyName("neutralHighCastle")]     public int NeutralHighCastleCount     { get; set; } = 0;
+        [JsonPropertyName("matchPlayerCastleFactions")] public bool MatchPlayerCastleFactions { get; set; } = false;
+        [JsonPropertyName("minNeutralZonesBetweenPlayers")] public int MinNeutralZonesBetweenPlayers { get; set; } = 0;
         [JsonPropertyName("heroMin")]           public int     HeroCountMin           { get; set; } = 10;
         [JsonPropertyName("heroMax")]           public int     HeroCountMax           { get; set; } = 10;
         [JsonPropertyName("heroIncrement")]     public int     HeroCountIncrement     { get; set; } = 0;

--- a/Olden Era - Template Editor/Models/SettingsFile.cs
+++ b/Olden Era - Template Editor/Models/SettingsFile.cs
@@ -23,6 +23,10 @@ namespace Olden_Era___Template_Editor.Models
         [JsonPropertyName("neutralHighCastle")]     public int NeutralHighCastleCount     { get; set; } = 0;
         [JsonPropertyName("matchPlayerCastleFactions")] public bool MatchPlayerCastleFactions { get; set; } = false;
         [JsonPropertyName("minNeutralZonesBetweenPlayers")] public int MinNeutralZonesBetweenPlayers { get; set; } = 0;
+        [JsonPropertyName("experimentalMapSizes")] public bool ExperimentalMapSizes { get; set; } = false;
+        [JsonPropertyName("playerZoneSize")]  public double  PlayerZoneSize       { get; set; } = 1.0;
+        [JsonPropertyName("neutralZoneSize")] public double  NeutralZoneSize      { get; set; } = 1.0;
+        [JsonPropertyName("guardRandomization")] public double GuardRandomization { get; set; } = 0.05;
         [JsonPropertyName("heroMin")]           public int     HeroCountMin           { get; set; } = 10;
         [JsonPropertyName("heroMax")]           public int     HeroCountMax           { get; set; } = 10;
         [JsonPropertyName("heroIncrement")]     public int     HeroCountIncrement     { get; set; } = 0;
@@ -35,6 +39,23 @@ namespace Olden_Era___Template_Editor.Models
         [JsonPropertyName("structureDensity")]  public int?    StructureDensityPercent      { get; set; }
         [JsonPropertyName("neutralStackStrength")] public int  NeutralStackStrengthPercent  { get; set; } = 100;
         [JsonPropertyName("borderGuardStrength")]  public int  BorderGuardStrengthPercent   { get; set; } = 100;
+        [JsonPropertyName("victoryCondition")]  public string  VictoryCondition             { get; set; } = "win_condition_1";
+        [JsonPropertyName("factionLawsExp")]    public int     FactionLawsExpPercent        { get; set; } = 100;
+        [JsonPropertyName("astrologyExp")]      public int     AstrologyExpPercent          { get; set; } = 100;
+        [JsonPropertyName("lostStartCity")]     public bool    LostStartCity                { get; set; } = false;
+        [JsonPropertyName("lostStartCityDay")]  public int     LostStartCityDay             { get; set; } = 3;
+        [JsonPropertyName("lostStartHero")]     public bool    LostStartHero                { get; set; } = false;
+        [JsonPropertyName("cityHold")]          public bool    CityHold                     { get; set; } = false;
+        [JsonPropertyName("cityHoldDays")]      public int     CityHoldDays                 { get; set; } = 6;
+        [JsonPropertyName("gladiatorArena")]    public bool    GladiatorArena               { get; set; } = false;
+        [JsonPropertyName("gladiatorArenaDaysDelayStart")] public int GladiatorArenaDaysDelayStart { get; set; } = 30;
+        [JsonPropertyName("gladiatorArenaCountDay")] public int GladiatorArenaCountDay       { get; set; } = 3;
+        [JsonPropertyName("tournament")]        public bool    Tournament                   { get; set; } = false;
+        [JsonPropertyName("tournamentRoundCount")] public int  TournamentRoundCount         { get; set; } = 3;
+        [JsonPropertyName("tournamentRoundDuration")] public int TournamentRoundDuration    { get; set; } = 3;
+        [JsonPropertyName("tournamentFirstAnnounceDay")] public int TournamentFirstAnnounceDay { get; set; } = 7;
+        [JsonPropertyName("tournamentRoundInterval")] public int TournamentRoundInterval    { get; set; } = 7;
+        [JsonPropertyName("tournamentPointsToWin")] public int TournamentPointsToWin        { get; set; } = 2;
 
         // Legacy setting from v0.2 and earlier; when present, it seeds both split density sliders.
         [JsonPropertyName("contentDensity")]    public int?    ContentDensityPercent        { get; set; }

--- a/Olden Era - Template Editor/Olden Era - Template Editor.csproj
+++ b/Olden Era - Template Editor/Olden Era - Template Editor.csproj
@@ -7,9 +7,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>0.2.0</Version>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
+    <Version>0.3.0</Version>
+    <AssemblyVersion>0.3.0.0</AssemblyVersion>
+    <FileVersion>0.3.0.0</FileVersion>
     <AssemblyName>OldenEraTemplateGenerator</AssemblyName>
     <!-- Publish as a single self-contained .exe with no extra files -->
     <PublishSingleFile>true</PublishSingleFile>

--- a/Olden Era - Template Editor/Services/TemplateGenerator.cs
+++ b/Olden Era - Template Editor/Services/TemplateGenerator.cs
@@ -14,20 +14,25 @@ namespace Olden_Era___Template_Editor.Services
         // Each player zone gets 5 guard connections to the center (same as JCC).
         private const int ConnectionsPerZone = 5;
 
-        // Letters used to name zones: A, B, C … up to 8 players + 8 neutral zones = 16 max.
+        // Labels used to name zones, up to the advanced-mode maximum of 32 total zones.
         private static readonly string[] ZoneLetters =
-            ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P"];
+        [
+            "A", "B", "C", "D", "E", "F", "G", "H",
+            "I", "J", "K", "L", "M", "N", "O", "P",
+            "Q", "R", "S", "T", "U", "V", "W", "X",
+            "Y", "Z", "AA", "AB", "AC", "AD", "AE", "AF"
+        ];
 
         public static RmgTemplate Generate(GeneratorSettings settings)
         {
             var playerLetters = ZoneLetters.Take(settings.PlayerCount).ToList();
+            var neutralZones = BuildNeutralZonePlan(settings);
 
             // Hub & Spoke handles isolation via hub; for all other topologies the
             // isolation is done by skipping player–player connections, so no extra
             // neutral zones need to be auto-created.
-            int neutralCount = settings.NeutralZoneCount;
-
-            var neutralLetters = ZoneLetters.Skip(settings.PlayerCount).Take(neutralCount).ToList();
+            int neutralCount = neutralZones.Count;
+            var neutralLetters = neutralZones.Select(zone => zone.Letter).ToList();
 
             int totalZones = settings.PlayerCount + neutralCount;
             var tuning = new GenerationTuning(
@@ -46,15 +51,74 @@ namespace Olden_Era___Template_Editor.Services
                 SizeX = settings.MapSize,
                 SizeZ = settings.MapSize,
                 GameRules = BuildGameRules(settings),
-                Variants = [BuildVariant(settings, playerLetters, neutralLetters, tuning)],
+                Variants = [BuildVariant(settings, playerLetters, neutralZones, tuning)],
                 ZoneLayouts = BuildZoneLayouts(),
-                MandatoryContent = BuildAllMandatoryContent(playerLetters, neutralLetters, settings),
+                MandatoryContent = BuildAllMandatoryContent(playerLetters, neutralZones, settings),
                 ContentCountLimits = BuildAllContentCountLimits(),
                 ContentPools = [],
                 ContentLists = []
             };
 
             return template;
+        }
+
+        private sealed record NeutralZonePlan(string Letter, NeutralZoneQuality Quality, int CastleCount);
+
+        private sealed record NeutralZoneProfile(
+            double GuardMultiplier,
+            string GuardedContentPool,
+            string UnguardedContentPool,
+            string ResourcesContentPool,
+            int GuardedContentValue,
+            int GuardedContentValuePerArea,
+            int UnguardedContentValue,
+            int UnguardedContentValuePerArea,
+            int ResourcesValue,
+            int ResourcesValuePerArea,
+            int PrimaryCityGuardValue,
+            int ExtraCityGuardValue,
+            string PrimaryBuildingsConstructionSid,
+            string ExtraBuildingsConstructionSid);
+
+        private static List<NeutralZonePlan> BuildNeutralZonePlan(GeneratorSettings settings)
+        {
+            var plans = new List<NeutralZonePlan>();
+            int maxNeutralZones = Math.Max(0, ZoneLetters.Length - settings.PlayerCount);
+            int castleZoneCastleCount = Math.Clamp(settings.NeutralZoneCastles, 1, 4);
+
+            void Add(int requestedCount, NeutralZoneQuality quality, int castleCount)
+            {
+                int count = Math.Clamp(requestedCount, 0, 8);
+                for (int i = 0; i < count && plans.Count < maxNeutralZones; i++)
+                {
+                    string letter = ZoneLetters[settings.PlayerCount + plans.Count];
+                    plans.Add(new NeutralZonePlan(letter, quality, castleCount));
+                }
+            }
+
+            if (settings.AdvancedMode)
+            {
+                Add(settings.NeutralLowNoCastleCount, NeutralZoneQuality.Low, 0);
+                Add(settings.NeutralLowCastleCount, NeutralZoneQuality.Low, castleZoneCastleCount);
+                Add(settings.NeutralMediumNoCastleCount, NeutralZoneQuality.Medium, 0);
+                Add(settings.NeutralMediumCastleCount, NeutralZoneQuality.Medium, castleZoneCastleCount);
+                Add(settings.NeutralHighNoCastleCount, NeutralZoneQuality.High, 0);
+                Add(settings.NeutralHighCastleCount, NeutralZoneQuality.High, castleZoneCastleCount);
+            }
+            else
+            {
+                int castleCount = Math.Clamp(settings.NeutralZoneCastles, 0, 4);
+                Add(settings.NeutralZoneCount, NeutralZoneQuality.Medium, castleCount);
+            }
+
+            if (settings.Topology == MapTopology.SharedWeb && plans.Count == 0 && maxNeutralZones > 0)
+            {
+                string letter = ZoneLetters[settings.PlayerCount];
+                int castleCount = Math.Clamp(settings.NeutralZoneCastles, 0, 4);
+                plans.Add(new NeutralZonePlan(letter, NeutralZoneQuality.Medium, castleCount));
+            }
+
+            return plans;
         }
 
         // ── Game rules ───────────────────────────────────────────────────────────
@@ -133,9 +197,50 @@ namespace Olden_Era___Template_Editor.Services
             return Math.Clamp(Math.Sqrt(zoneArea / referenceArea), 0.5, 2.5);
         }
 
+        public static bool CanHonorNeutralSeparation(GeneratorSettings settings, int neutralZoneCount)
+        {
+            int min = settings.MinNeutralZonesBetweenPlayers;
+            if (min <= 0) return true;
+            if (settings.RandomPortals) return false;
+
+            return settings.Topology switch
+            {
+                MapTopology.Default => neutralZoneCount >= settings.PlayerCount * min,
+                MapTopology.Chain => neutralZoneCount >= (settings.PlayerCount - 1) * min,
+                MapTopology.HubAndSpoke => min <= 1,
+                MapTopology.SharedWeb => min <= 1 && neutralZoneCount >= 1,
+                _ => false,
+            };
+        }
+
+        private static List<string> BuildOrderedLetters(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, bool isRing)
+        {
+            int min = settings.MinNeutralZonesBetweenPlayers;
+            if (min <= 0 || settings.RandomPortals || !CanHonorNeutralSeparation(settings, neutralLetters.Count))
+                return playerLetters.Concat(neutralLetters).ToList();
+
+            var ordered = new List<string>();
+            var remainingNeutrals = new Queue<string>(neutralLetters);
+
+            for (int i = 0; i < playerLetters.Count; i++)
+            {
+                ordered.Add(playerLetters[i]);
+                bool needsSeparatorAfterPlayer = isRing || i < playerLetters.Count - 1;
+                if (!needsSeparatorAfterPlayer) continue;
+
+                for (int j = 0; j < min && remainingNeutrals.Count > 0; j++)
+                    ordered.Add(remainingNeutrals.Dequeue());
+            }
+
+            while (remainingNeutrals.Count > 0)
+                ordered.Add(remainingNeutrals.Dequeue());
+
+            return ordered.Count > 0 ? ordered : playerLetters.Concat(neutralLetters).ToList();
+        }
+
         // ── Variant ──────────────────────────────────────────────────────────────
 
-        private static Variant BuildVariant(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
+        private static Variant BuildVariant(GeneratorSettings settings, List<string> playerLetters, List<NeutralZonePlan> neutralZones, GenerationTuning tuning)
         {
             // Shuffle player letters so Player 1 is not always at the same geometric position.
             var rng = new Random();
@@ -144,19 +249,21 @@ namespace Olden_Era___Template_Editor.Services
 
             return settings.Topology switch
             {
-                MapTopology.HubAndSpoke => BuildVariantHubAndSpoke(settings, playerLetters, neutralLetters, tuning),
-                MapTopology.Chain       => BuildVariantChain(settings, playerLetters, neutralLetters, tuning),
-                MapTopology.SharedWeb   => BuildVariantSharedWeb(settings, playerLetters, neutralLetters, tuning),
-                MapTopology.Random      => BuildVariantRandom(settings, playerLetters, neutralLetters, tuning),
-                _                       => BuildVariantDefault(settings, playerLetters, neutralLetters, tuning),
+                MapTopology.HubAndSpoke => BuildVariantHubAndSpoke(settings, playerLetters, neutralZones, tuning),
+                MapTopology.Chain       => BuildVariantChain(settings, playerLetters, neutralZones, tuning),
+                MapTopology.SharedWeb   => BuildVariantSharedWeb(settings, playerLetters, neutralZones, tuning),
+                MapTopology.Random      => BuildVariantRandom(settings, playerLetters, neutralZones, tuning),
+                _                       => BuildVariantDefault(settings, playerLetters, neutralZones, tuning),
             };
         }
 
         // ── Topology: Default (Ring) ──────────────────────────────────────────────
 
-        private static Variant BuildVariantDefault(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
+        private static Variant BuildVariantDefault(GeneratorSettings settings, List<string> playerLetters, List<NeutralZonePlan> neutralZones, GenerationTuning tuning)
         {
-            var orderedLetters = playerLetters.Concat(neutralLetters).ToList();
+            var neutralByLetter = neutralZones.ToDictionary(zone => zone.Letter);
+            var neutralLetters = neutralZones.Select(zone => zone.Letter).ToList();
+            var orderedLetters = BuildOrderedLetters(settings, playerLetters, neutralLetters, isRing: true);
             int outerCount = orderedLetters.Count;
             bool isolate = settings.NoDirectPlayerConnections && playerLetters.Count > 1;
 
@@ -185,9 +292,9 @@ namespace Olden_Era___Template_Editor.Services
 
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(letter, myConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildNeutralZone(neutralByLetter[letter], myConns, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             var connections = new List<Connection>();
@@ -201,9 +308,11 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Topology: Random Proximity ────────────────────────────────────────────
 
-        private static Variant BuildVariantRandom(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
+        private static Variant BuildVariantRandom(GeneratorSettings settings, List<string> playerLetters, List<NeutralZonePlan> neutralZones, GenerationTuning tuning)
         {
             var rng = new Random();
+            var neutralByLetter = neutralZones.ToDictionary(zone => zone.Letter);
+            var neutralLetters = neutralZones.Select(zone => zone.Letter).ToList();
             // Shuffle zones so player/neutral order is random.
             var allLetters = playerLetters.Concat(neutralLetters).OrderBy(_ => rng.Next()).ToList();
             int count = allLetters.Count;
@@ -216,7 +325,7 @@ namespace Olden_Era___Template_Editor.Services
                 pos.Add((rng.NextDouble() * 0.9 + 0.05, rng.NextDouble() * 0.9 + 0.05));
 
             // Compute Delaunay triangulation — every edge is a true zone-to-zone border.
-            // With only ≤16 points this is fast enough to do with Bowyer-Watson.
+            // With only up to 32 points this is fast enough to do with Bowyer-Watson.
             var pairs = DelaunayEdges(pos);
 
             // Build connection name lookup per zone index.
@@ -258,9 +367,9 @@ namespace Olden_Era___Template_Editor.Services
                 var myConns = connsByZone[i].ToArray();
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(letter, myConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildNeutralZone(neutralByLetter[letter], myConns, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             if (settings.RandomPortals)
@@ -352,10 +461,12 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Topology: Hub & Spoke ─────────────────────────────────────────────────
 
-        private static Variant BuildVariantHubAndSpoke(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
+        private static Variant BuildVariantHubAndSpoke(GeneratorSettings settings, List<string> playerLetters, List<NeutralZonePlan> neutralZones, GenerationTuning tuning)
         {
             // A central "Hub" zone connects to every outer zone.
             // Outer zones are players + neutrals arranged around the hub.
+            var neutralByLetter = neutralZones.ToDictionary(zone => zone.Letter);
+            var neutralLetters = neutralZones.Select(zone => zone.Letter).ToList();
             var outerLetters = playerLetters.Concat(neutralLetters).ToList();
             var zones = new List<Zone>();
             var connections = new List<Connection>();
@@ -371,9 +482,9 @@ namespace Olden_Era___Template_Editor.Services
                 var spokeConns = new[] { $"Hub-{letter}" };
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", spokeConns, settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", spokeConns, settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(letter, spokeConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildNeutralZone(neutralByLetter[letter], spokeConns, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             // Hub → each outer zone: Direct guarded connections (multiple per zone like JCC).
@@ -424,9 +535,11 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Topology: Chain ───────────────────────────────────────────────────────
 
-        private static Variant BuildVariantChain(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
+        private static Variant BuildVariantChain(GeneratorSettings settings, List<string> playerLetters, List<NeutralZonePlan> neutralZones, GenerationTuning tuning)
         {
-            var orderedLetters = playerLetters.Concat(neutralLetters).ToList();
+            var neutralByLetter = neutralZones.ToDictionary(zone => zone.Letter);
+            var neutralLetters = neutralZones.Select(zone => zone.Letter).ToList();
+            var orderedLetters = BuildOrderedLetters(settings, playerLetters, neutralLetters, isRing: false);
             int count = orderedLetters.Count;
             bool isolate = settings.NoDirectPlayerConnections && playerLetters.Count > 1;
 
@@ -451,9 +564,9 @@ namespace Olden_Era___Template_Editor.Services
 
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns.ToArray(), settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns.ToArray(), settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(letter, myConns.ToArray(), settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildNeutralZone(neutralByLetter[letter], myConns.ToArray(), settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             var connections = new List<Connection>();
@@ -488,15 +601,14 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Topology: Shared Web ──────────────────────────────────────────────────
 
-        private static Variant BuildVariantSharedWeb(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
+        private static Variant BuildVariantSharedWeb(GeneratorSettings settings, List<string> playerLetters, List<NeutralZonePlan> neutralZones, GenerationTuning tuning)
         {
             // Each player connects to two neutral zones.
             // Neutral zones are arranged in a ring connecting all players.
             // If there are fewer neutrals than needed, we wrap around (multiple players share a neutral).
             // Requires at least 1 neutral zone.
-            var neutrals = neutralLetters.Count > 0
-                ? neutralLetters
-                : ZoneLetters.Skip(settings.PlayerCount).Take(1).ToList();
+            var neutralByLetter = neutralZones.ToDictionary(zone => zone.Letter);
+            var neutrals = neutralZones.Select(zone => zone.Letter).ToList();
 
             int p = playerLetters.Count;
             int n = neutrals.Count;
@@ -519,7 +631,7 @@ namespace Olden_Era___Template_Editor.Services
                 string[] nConns = n > 1
                     ? new[] { neutralRingConns[prev], neutralRingConns[i] }.Distinct().ToArray()
                     : [];
-                zones.Add(BuildNeutralZone(neutrals[i], nConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                zones.Add(BuildNeutralZone(neutralByLetter[neutrals[i]], nConns, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             // Build player zones — each connects to two neutrals (evenly distributed).
@@ -533,7 +645,7 @@ namespace Olden_Era___Template_Editor.Services
                 if (n1 != n2)
                     spokeConns.Add($"Web-{playerLetters[i]}-{neutrals[n2]}");
 
-                zones.Add(BuildSpawnZone(playerLetters[i], $"Player{i + 1}", spokeConns.ToArray(), settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                zones.Add(BuildSpawnZone(playerLetters[i], $"Player{i + 1}", spokeConns.ToArray(), settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
 
                 // Player → neutral Direct connections.
                 foreach (var connName in spokeConns)
@@ -727,9 +839,9 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Spawn zone ───────────────────────────────────────────────────────────
 
-        private static Zone BuildSpawnZone(string letter, string player, string[] ringConns, int castleCount, bool spawnFootholds, bool generateRoads, GenerationTuning tuning)
+        private static Zone BuildSpawnZone(string letter, string player, string[] ringConns, int castleCount, bool matchCastleFactions, bool spawnFootholds, bool generateRoads, GenerationTuning tuning)
         {
-            // Index 0 = Spawn (player town), indices 1..castleCount = extra same-faction cities.
+            // Index 0 = Spawn (player town), indices 1..castleCount-1 = extra cities.
             var mainObjects = new List<MainObject>
             {
                 new()
@@ -751,7 +863,9 @@ namespace Olden_Era___Template_Editor.Services
                 mainObjects.Add(new MainObject
                 {
                     Type = "City",
-                    Faction = new TypedSelector { Type = "Random", Args = [] },
+                    Faction = matchCastleFactions
+                        ? new TypedSelector { Type = "Match", Args = ["0"] }
+                        : new TypedSelector { Type = "Random", Args = [] },
                     GuardChance = 0.5,
                     GuardValue = ScaleNeutralGuardValue(2500, tuning),
                     GuardWeeklyIncrement = 0.10,
@@ -794,19 +908,21 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Neutral zone ─────────────────────────────────────────────────────────
 
-        private static Zone BuildNeutralZone(string letter, string[] ringConns, int castleCount, bool spawnFootholds, bool generateRoads, GenerationTuning tuning)
+        private static Zone BuildNeutralZone(NeutralZonePlan plan, string[] ringConns, bool spawnFootholds, bool generateRoads, GenerationTuning tuning)
         {
-            // Index 0 = primary neutral city; indices 1..castleCount-1 = extra neutral cities.
-            // All cities use FromList [] (neutral faction, not biome-matched).
+            string letter = plan.Letter;
+            int castleCount = plan.CastleCount;
+            var profile = GetNeutralZoneProfile(plan.Quality);
+
             var mainObjects = new List<MainObject>();
             if (castleCount > 0)
                 mainObjects.Add(new MainObject
                 {
                     Type = "City",
                     GuardChance = 0.5,
-                    GuardValue = ScaleNeutralGuardValue(10000, tuning),
+                    GuardValue = ScaleNeutralGuardValue(profile.PrimaryCityGuardValue, tuning),
                     GuardWeeklyIncrement = 0.10,
-                    BuildingsConstructionSid = "rich_buildings_construction",
+                    BuildingsConstructionSid = profile.PrimaryBuildingsConstructionSid,
                     Faction = new TypedSelector { Type = "FromList", Args = [] },
                     Placement = "Uniform",
                     PlacementArgs = ["true", "0.8", "2"]
@@ -818,9 +934,9 @@ namespace Olden_Era___Template_Editor.Services
                 {
                     Type = "City",
                     GuardChance = 0.5,
-                    GuardValue = ScaleNeutralGuardValue(5000, tuning),
+                    GuardValue = ScaleNeutralGuardValue(profile.ExtraCityGuardValue, tuning),
                     GuardWeeklyIncrement = 0.10,
-                    BuildingsConstructionSid = "poor_buildings_construction",
+                    BuildingsConstructionSid = profile.ExtraBuildingsConstructionSid,
                     Faction = new TypedSelector { Type = "FromList", Args = [] },
                     Placement = "Uniform",
                     PlacementArgs = ["false", "-0.8", "3"]
@@ -834,21 +950,21 @@ namespace Olden_Era___Template_Editor.Services
                 Layout = "zone_layout_spawns",
                 GuardCutoffValue = 2000,
                 GuardRandomization = 0.05,
-                GuardMultiplier = ScaleGuardMultiplier(1.3, tuning),
+                GuardMultiplier = ScaleGuardMultiplier(profile.GuardMultiplier, tuning),
                 GuardWeeklyIncrement = 0.20,
-                GuardReactionDistribution = [0, 10, 10, 10, 10, 0],
+                GuardReactionDistribution = plan.Quality == NeutralZoneQuality.High ? [0, 10, 10, 20, 10, 0] : [0, 10, 10, 10, 10, 0],
                 DiplomacyModifier = -0.5,
-                GuardedContentPool = ["template_pool_jebus_cross_guarded_side_zone"],
-                UnguardedContentPool = ["template_pool_jebus_cross_unguarded_side_zone"],
-                ResourcesContentPool = ["content_pool_general_resources_start_zone_rich"],
+                GuardedContentPool = [profile.GuardedContentPool],
+                UnguardedContentPool = [profile.UnguardedContentPool],
+                ResourcesContentPool = [profile.ResourcesContentPool],
                 MandatoryContent = [$"mandatory_content_neutral_{letter}"],
                 ContentCountLimits = BuildSideContentLimits(),
-                GuardedContentValue = ScaleStructureValue(260000 * tuning.ContentScale, tuning),
-                GuardedContentValuePerArea = ScaleStructureValue(2400 * Math.Sqrt(tuning.ContentScale), tuning),
-                UnguardedContentValue = ScaleStructureValue(40000 * tuning.ContentScale, tuning),
-                UnguardedContentValuePerArea = ScaleStructureValue(320 * Math.Sqrt(tuning.ContentScale), tuning),
-                ResourcesValue = ScaleResourceValue(60000 * tuning.ContentScale, tuning),
-                ResourcesValuePerArea = ScaleResourceValue(480 * Math.Sqrt(tuning.ContentScale), tuning),
+                GuardedContentValue = ScaleStructureValue(profile.GuardedContentValue * tuning.ContentScale, tuning),
+                GuardedContentValuePerArea = ScaleStructureValue(profile.GuardedContentValuePerArea * Math.Sqrt(tuning.ContentScale), tuning),
+                UnguardedContentValue = ScaleStructureValue(profile.UnguardedContentValue * tuning.ContentScale, tuning),
+                UnguardedContentValuePerArea = ScaleStructureValue(profile.UnguardedContentValuePerArea * Math.Sqrt(tuning.ContentScale), tuning),
+                ResourcesValue = ScaleResourceValue(profile.ResourcesValue * tuning.ContentScale, tuning),
+                ResourcesValuePerArea = ScaleResourceValue(profile.ResourcesValuePerArea * Math.Sqrt(tuning.ContentScale), tuning),
                 MainObjects = mainObjects,
                 ZoneBiome = castleCount > 0
                     ? new BiomeSelector { Type = "MatchMainObject", Args = ["0"] }
@@ -863,6 +979,55 @@ namespace Olden_Era___Template_Editor.Services
                 Roads = BuildOuterZoneRoads(ringConns, castleCount, spawnFootholds, generateRoads)
             };
         }
+
+        private static NeutralZoneProfile GetNeutralZoneProfile(NeutralZoneQuality quality) => quality switch
+        {
+            NeutralZoneQuality.Low => new NeutralZoneProfile(
+                1.0,
+                "template_pool_jebus_cross_guarded_start_zone",
+                "template_pool_jebus_cross_unguarded_start_zone",
+                "content_pool_general_resources_start_zone_rich",
+                140000,
+                1200,
+                30000,
+                240,
+                40000,
+                320,
+                5000,
+                2500,
+                "poor_buildings_construction",
+                "poor_buildings_construction"),
+            NeutralZoneQuality.High => new NeutralZoneProfile(
+                1.6,
+                "template_pool_jebus_cross_guarded_center_zone",
+                "template_pool_jebus_cross_unguarded_center_zone",
+                "content_pool_general_resources_treasure_zone_rich_no_scrolls",
+                520000,
+                3200,
+                90000,
+                700,
+                100000,
+                650,
+                18000,
+                9000,
+                "rich_buildings_construction",
+                "rich_buildings_construction"),
+            _ => new NeutralZoneProfile(
+                1.3,
+                "template_pool_jebus_cross_guarded_side_zone",
+                "template_pool_jebus_cross_unguarded_side_zone",
+                "content_pool_general_resources_start_zone_rich",
+                260000,
+                2400,
+                40000,
+                320,
+                60000,
+                480,
+                10000,
+                5000,
+                "rich_buildings_construction",
+                "poor_buildings_construction"),
+        };
 
         // ── Connections
 
@@ -1081,15 +1246,15 @@ namespace Olden_Era___Template_Editor.Services
         // ── Mandatory content ────────────────────────────────────────────────────
 
         private static List<MandatoryContentGroup> BuildAllMandatoryContent(
-            List<string> playerLetters, List<string> neutralLetters, GeneratorSettings settings)
+            List<string> playerLetters, List<NeutralZonePlan> neutralZones, GeneratorSettings settings)
         {
             var groups = new List<MandatoryContentGroup>();
 
             foreach (var letter in playerLetters)
                 groups.Add(BuildSpawnMandatoryContent(letter, settings.PlayerZoneCastles, settings.SpawnRemoteFootholds));
 
-            foreach (var letter in neutralLetters)
-                groups.Add(BuildNeutralMandatoryContent(letter, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds));
+            foreach (var neutralZone in neutralZones)
+                groups.Add(BuildNeutralMandatoryContent(neutralZone.Letter, neutralZone.CastleCount, settings.SpawnRemoteFootholds));
 
             return groups;
         }
@@ -1117,8 +1282,9 @@ namespace Olden_Era___Template_Editor.Services
             var footholdRules = new List<ContentPlacementRule>
             {
                 new() { Type = "Crossroads", Args = [], TargetMin = 0.2, TargetMax = 0.3, Weight = 0 },
-                new() { Type = "MainObject", Args = ["0"], TargetMin = 0.2, TargetMax = 0.4, Weight = 0 },
             };
+            if (castleCount > 0)
+                footholdRules.Add(new ContentPlacementRule { Type = "MainObject", Args = ["0"], TargetMin = 0.2, TargetMax = 0.4, Weight = 0 });
             if (castleCount > 1)
                 footholdRules.Add(new ContentPlacementRule { Type = "MainObject", Args = ["1"], TargetMin = 0.5, TargetMax = 0.5, Weight = 2 });
 

--- a/Olden Era - Template Editor/Services/TemplateGenerator.cs
+++ b/Olden Era - Template Editor/Services/TemplateGenerator.cs
@@ -56,7 +56,7 @@ namespace Olden_Era___Template_Editor.Services
             {
                 Name = settings.TemplateName,
                 GameMode = settings.GameMode,
-                Description = "custom_generated_template",
+                Description = BuildTemplateDescription(settings, neutralCount),
                 DisplayWinCondition = effectiveVictoryCondition,
                 SizeX = settings.MapSize,
                 SizeZ = settings.MapSize,
@@ -71,6 +71,57 @@ namespace Olden_Era___Template_Editor.Services
 
             return template;
         }
+
+        private static string BuildTemplateDescription(GeneratorSettings settings, int neutralZoneCount)
+        {
+            var parts = new List<string>
+            {
+                $"{settings.GameMode} mode",
+                CountPhrase(settings.PlayerCount, "player", "players"),
+                $"{settings.MapSize}x{settings.MapSize} map",
+                $"{TopologyLabel(settings.Topology)} layout",
+                CountPhrase(neutralZoneCount, "neutral zone", "neutral zones"),
+                $"{CountPhrase(settings.PlayerZoneCastles, "castle", "castles")} per player zone"
+            };
+
+            if (neutralZoneCount > 0)
+            {
+                string neutralCastlePhrase = settings.AdvancedMode
+                    ? "mixed neutral zone tiers"
+                    : $"{CountPhrase(settings.NeutralZoneCastles, "castle", "castles")} per neutral zone";
+                parts.Add(neutralCastlePhrase);
+            }
+
+            var options = new List<string>();
+            if (settings.NoDirectPlayerConnections)
+                options.Add("isolated player starts");
+            if (settings.ExperimentalBalancedZonePlacement)
+                options.Add("experimental balanced zone placement");
+            if (settings.RandomPortals)
+                options.Add("random portals");
+            if (!settings.SpawnRemoteFootholds)
+                options.Add("no remote footholds");
+            if (!settings.GenerateRoads)
+                options.Add("roads disabled");
+
+            if (options.Count > 0)
+                parts.Add($"options: {string.Join(", ", options)}");
+
+            return $"Generated with Olden Era Template Generator: {string.Join(", ", parts)}.";
+        }
+
+        private static string CountPhrase(int count, string singular, string plural) =>
+            count == 0 ? $"no {plural}" : $"{count} {(count == 1 ? singular : plural)}";
+
+        private static string TopologyLabel(MapTopology topology) => topology switch
+        {
+            MapTopology.Default => "Ring",
+            MapTopology.HubAndSpoke => "Hub",
+            MapTopology.Chain => "Chain",
+            MapTopology.SharedWeb => "Shared Web",
+            MapTopology.Random => "Random",
+            _ => topology.ToString()
+        };
 
         private sealed record NeutralZonePlan(string Letter, NeutralZoneQuality Quality, int CastleCount);
 
@@ -309,8 +360,22 @@ namespace Olden_Era___Template_Editor.Services
             };
         }
 
-        private static List<string> BuildOrderedLetters(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, bool isRing)
+        private static List<string> BuildOrderedLetters(GeneratorSettings settings, List<string> playerLetters, List<NeutralZonePlan> neutralZones, bool isRing)
         {
+            var neutralLetters = neutralZones.Select(zone => zone.Letter).ToList();
+
+            if (settings.ExperimentalBalancedZonePlacement)
+            {
+                int honoredSeparation = settings.MinNeutralZonesBetweenPlayers > 0
+                    && CanHonorNeutralSeparation(settings, neutralLetters.Count)
+                        ? settings.MinNeutralZonesBetweenPlayers
+                        : 0;
+
+                return isRing
+                    ? BuildBalancedRingLetters(playerLetters, neutralZones, honoredSeparation)
+                    : BuildBalancedChainLetters(playerLetters, neutralZones, honoredSeparation);
+            }
+
             int min = settings.MinNeutralZonesBetweenPlayers;
             if (min <= 0 || settings.RandomPortals || !CanHonorNeutralSeparation(settings, neutralLetters.Count))
                 return playerLetters.Concat(neutralLetters).ToList();
@@ -334,14 +399,214 @@ namespace Olden_Era___Template_Editor.Services
             return ordered.Count > 0 ? ordered : playerLetters.Concat(neutralLetters).ToList();
         }
 
+        private static List<string> BuildBalancedRingLetters(
+            List<string> playerLetters,
+            List<NeutralZonePlan> neutralZones,
+            int minNeutralZonesBetweenPlayers)
+        {
+            if (playerLetters.Count == 0)
+                return BuildBalancedNeutralRing(neutralZones, 1);
+
+            if (neutralZones.Count == 0)
+                return [.. playerLetters];
+
+            int[] gapCapacities = BuildEvenGapCapacities(
+                playerLetters.Count,
+                neutralZones.Count,
+                minNeutralZonesBetweenPlayers);
+            var gaps = AssignNeutralZonesToGaps(neutralZones, gapCapacities, preferInteriorGaps: false);
+
+            var ordered = new List<string>(playerLetters.Count + neutralZones.Count);
+            for (int i = 0; i < playerLetters.Count; i++)
+            {
+                ordered.Add(playerLetters[i]);
+                ordered.AddRange(OrderNeutralsWithinGap(gaps[i]).Select(zone => zone.Letter));
+            }
+
+            return ordered;
+        }
+
+        private static List<string> BuildBalancedChainLetters(
+            List<string> playerLetters,
+            List<NeutralZonePlan> neutralZones,
+            int minNeutralZonesBetweenPlayers)
+        {
+            if (playerLetters.Count == 0)
+                return neutralZones.Select(zone => zone.Letter).ToList();
+
+            int gapCount = playerLetters.Count + 1;
+            var capacities = new int[gapCount];
+            int remaining = neutralZones.Count;
+
+            int requiredInterior = Math.Max(0, playerLetters.Count - 1) * minNeutralZonesBetweenPlayers;
+            if (minNeutralZonesBetweenPlayers > 0 && neutralZones.Count >= requiredInterior)
+            {
+                for (int i = 1; i < gapCount - 1; i++)
+                    capacities[i] = minNeutralZonesBetweenPlayers;
+                remaining -= requiredInterior;
+            }
+
+            int[] extras = BuildEvenGapCapacities(gapCount, remaining, minimumPerGap: 0);
+            for (int i = 0; i < gapCount; i++)
+                capacities[i] += extras[i];
+
+            var gaps = AssignNeutralZonesToGaps(neutralZones, capacities, preferInteriorGaps: true);
+            var ordered = new List<string>(playerLetters.Count + neutralZones.Count);
+
+            ordered.AddRange(OrderEdgeGap(gaps[0], highQualityNearPlayer: true).Select(zone => zone.Letter));
+            for (int i = 0; i < playerLetters.Count; i++)
+            {
+                ordered.Add(playerLetters[i]);
+                var gap = gaps[i + 1];
+                bool trailingEdge = i == playerLetters.Count - 1;
+                ordered.AddRange((trailingEdge
+                    ? OrderEdgeGap(gap, highQualityNearPlayer: false)
+                    : OrderNeutralsWithinGap(gap)).Select(zone => zone.Letter));
+            }
+
+            return ordered.Count > 0 ? ordered : playerLetters.Concat(neutralZones.Select(zone => zone.Letter)).ToList();
+        }
+
+        private static List<string> BuildBalancedNeutralRing(List<NeutralZonePlan> neutralZones, int playerCount)
+        {
+            if (neutralZones.Count <= 1)
+                return neutralZones.Select(zone => zone.Letter).ToList();
+
+            int gapCount = Math.Max(1, playerCount);
+            int[] gapCapacities = BuildEvenGapCapacities(gapCount, neutralZones.Count, minimumPerGap: 0);
+            var gaps = AssignNeutralZonesToGaps(neutralZones, gapCapacities, preferInteriorGaps: false);
+            return gaps
+                .SelectMany(gap => OrderNeutralsWithinGap(gap))
+                .Select(zone => zone.Letter)
+                .ToList();
+        }
+
+        private static int[] BuildEvenGapCapacities(int gapCount, int itemCount, int minimumPerGap)
+        {
+            var capacities = new int[Math.Max(0, gapCount)];
+            if (gapCount <= 0 || itemCount <= 0)
+                return capacities;
+
+            int minimum = Math.Max(0, minimumPerGap);
+            int reserved = minimum * gapCount;
+            int remaining = itemCount;
+            if (minimum > 0 && itemCount >= reserved)
+            {
+                for (int i = 0; i < gapCount; i++)
+                    capacities[i] = minimum;
+                remaining -= reserved;
+            }
+
+            for (int i = 0; i < remaining; i++)
+            {
+                int gap = (int)Math.Floor((i + 0.5) * gapCount / remaining);
+                capacities[Math.Clamp(gap, 0, gapCount - 1)]++;
+            }
+
+            return capacities;
+        }
+
+        private static List<List<NeutralZonePlan>> AssignNeutralZonesToGaps(
+            List<NeutralZonePlan> neutralZones,
+            int[] gapCapacities,
+            bool preferInteriorGaps)
+        {
+            var gaps = gapCapacities.Select(_ => new List<NeutralZonePlan>()).ToList();
+            var loads = new double[gapCapacities.Length];
+            var orderedNeutrals = neutralZones
+                .OrderByDescending(NeutralZoneBalanceScore)
+                .ThenBy(zone => zone.Letter, StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var neutralZone in orderedNeutrals)
+            {
+                var candidates = Enumerable.Range(0, gapCapacities.Length)
+                    .Where(i => gaps[i].Count < gapCapacities[i])
+                    .ToList();
+
+                if (candidates.Count == 0)
+                    break;
+
+                if (preferInteriorGaps)
+                {
+                    var interiorCandidates = candidates
+                        .Where(i => i > 0 && i < gapCapacities.Length - 1)
+                        .ToList();
+                    if (interiorCandidates.Count > 0)
+                        candidates = interiorCandidates;
+                }
+
+                int selectedGap = candidates
+                    .OrderBy(i => loads[i])
+                    .ThenBy(i => gaps[i].Count)
+                    .ThenBy(i => i)
+                    .First();
+
+                gaps[selectedGap].Add(neutralZone);
+                loads[selectedGap] += NeutralZoneBalanceScore(neutralZone);
+            }
+
+            return gaps;
+        }
+
+        private static List<NeutralZonePlan> OrderNeutralsWithinGap(List<NeutralZonePlan> neutralZones)
+        {
+            int count = neutralZones.Count;
+            if (count <= 1)
+                return [.. neutralZones];
+
+            var sorted = neutralZones
+                .OrderByDescending(NeutralZoneBalanceScore)
+                .ThenBy(zone => zone.Letter, StringComparer.Ordinal)
+                .ToList();
+            var slots = new NeutralZonePlan[count];
+            var positions = Enumerable.Range(0, count)
+                .OrderBy(position => Math.Abs(position - (count - 1) / 2.0))
+                .ThenBy(position => position)
+                .ToList();
+
+            for (int i = 0; i < sorted.Count; i++)
+                slots[positions[i]] = sorted[i];
+
+            return slots.ToList();
+        }
+
+        private static List<NeutralZonePlan> OrderEdgeGap(List<NeutralZonePlan> neutralZones, bool highQualityNearPlayer)
+        {
+            var ordered = neutralZones
+                .OrderBy(zone => NeutralZoneBalanceScore(zone))
+                .ThenBy(zone => zone.Letter, StringComparer.Ordinal)
+                .ToList();
+
+            if (highQualityNearPlayer)
+                return ordered;
+
+            ordered.Reverse();
+            return ordered;
+        }
+
+        private static double NeutralZoneBalanceScore(NeutralZonePlan zone)
+        {
+            double quality = zone.Quality switch
+            {
+                NeutralZoneQuality.High => 3.0,
+                NeutralZoneQuality.Medium => 2.0,
+                _ => 1.0
+            };
+
+            return quality + Math.Min(zone.CastleCount, 4) * 0.15;
+        }
+
         // ── Variant ──────────────────────────────────────────────────────────────
 
         private static Variant BuildVariant(GeneratorSettings settings, List<string> playerLetters, List<NeutralZonePlan> neutralZones, GenerationTuning tuning)
         {
             // Shuffle player letters so Player 1 is not always at the same geometric position.
-            var rng = new Random();
-           
-            playerLetters = [.. playerLetters.OrderBy(_ => rng.Next())];
+            if (!settings.ExperimentalBalancedZonePlacement)
+            {
+                var rng = new Random();
+                playerLetters = [.. playerLetters.OrderBy(_ => rng.Next())];
+            }
 
             return settings.Topology switch
             {
@@ -358,8 +623,7 @@ namespace Olden_Era___Template_Editor.Services
         private static Variant BuildVariantDefault(GeneratorSettings settings, List<string> playerLetters, List<NeutralZonePlan> neutralZones, GenerationTuning tuning)
         {
             var neutralByLetter = neutralZones.ToDictionary(zone => zone.Letter);
-            var neutralLetters = neutralZones.Select(zone => zone.Letter).ToList();
-            var orderedLetters = BuildOrderedLetters(settings, playerLetters, neutralLetters, isRing: true);
+            var orderedLetters = BuildOrderedLetters(settings, playerLetters, neutralZones, isRing: true);
             int outerCount = orderedLetters.Count;
             bool isolate = settings.NoDirectPlayerConnections && playerLetters.Count > 1;
 
@@ -410,15 +674,22 @@ namespace Olden_Era___Template_Editor.Services
             var neutralByLetter = neutralZones.ToDictionary(zone => zone.Letter);
             var neutralLetters = neutralZones.Select(zone => zone.Letter).ToList();
             // Shuffle zones so player/neutral order is random.
-            var allLetters = playerLetters.Concat(neutralLetters).OrderBy(_ => rng.Next()).ToList();
+            var allLetters = settings.ExperimentalBalancedZonePlacement
+                ? BuildBalancedRingLetters(playerLetters, neutralZones, minNeutralZonesBetweenPlayers: 0)
+                : playerLetters.Concat(neutralLetters).OrderBy(_ => rng.Next()).ToList();
             int count = allLetters.Count;
             bool isolate = settings.NoDirectPlayerConnections && playerLetters.Count > 1;
 
             // Assign random 2D positions in the unit square.
             // Jitter positions slightly apart to avoid degenerate collinear/cocircular cases.
-            var pos = new List<(double X, double Y)>();
-            for (int i = 0; i < count; i++)
-                pos.Add((rng.NextDouble() * 0.9 + 0.05, rng.NextDouble() * 0.9 + 0.05));
+            var pos = settings.ExperimentalBalancedZonePlacement
+                ? BuildBalancedRandomPositions(allLetters, playerLetters, neutralByLetter)
+                : new List<(double X, double Y)>();
+            if (!settings.ExperimentalBalancedZonePlacement)
+            {
+                for (int i = 0; i < count; i++)
+                    pos.Add((rng.NextDouble() * 0.9 + 0.05, rng.NextDouble() * 0.9 + 0.05));
+            }
 
             // Compute Delaunay triangulation — every edge is a true zone-to-zone border.
             // With only up to 32 points this is fast enough to do with Bowyer-Watson.
@@ -473,6 +744,35 @@ namespace Olden_Era___Template_Editor.Services
 
             if (isolate) EnsurePlayerZonesConnected(playerLetters, zones, connections, tuning);
             return MakeVariant(playerLetters, allLetters[0], count, zones, connections);
+        }
+
+        private static List<(double X, double Y)> BuildBalancedRandomPositions(
+            List<string> orderedLetters,
+            List<string> playerLetters,
+            Dictionary<string, NeutralZonePlan> neutralByLetter)
+        {
+            int count = orderedLetters.Count;
+            if (count == 0) return [];
+
+            var playerSet = playerLetters.ToHashSet(StringComparer.Ordinal);
+            var positions = new List<(double X, double Y)>(count);
+            for (int i = 0; i < count; i++)
+            {
+                string letter = orderedLetters[i];
+                bool isPlayer = playerSet.Contains(letter);
+                double angle = 2.0 * Math.PI * i / count;
+                double jitter = isPlayer ? 0.0 : ((i % 3) - 1) * 0.018;
+
+                double radius = 0.43;
+                if (!isPlayer && neutralByLetter.TryGetValue(letter, out var neutralZone))
+                    radius = 0.30 + NeutralZoneBalanceScore(neutralZone) * 0.035 + (i % 2) * 0.012;
+
+                positions.Add((
+                    Math.Clamp(0.5 + Math.Cos(angle + jitter) * radius, 0.05, 0.95),
+                    Math.Clamp(0.5 + Math.Sin(angle + jitter) * radius, 0.05, 0.95)));
+            }
+
+            return positions;
         }
 
         // ── Delaunay triangulation (Bowyer-Watson) ────────────────────────────────
@@ -563,7 +863,9 @@ namespace Olden_Era___Template_Editor.Services
             // Outer zones are players + neutrals arranged around the hub.
             var neutralByLetter = neutralZones.ToDictionary(zone => zone.Letter);
             var neutralLetters = neutralZones.Select(zone => zone.Letter).ToList();
-            var outerLetters = playerLetters.Concat(neutralLetters).ToList();
+            var outerLetters = settings.ExperimentalBalancedZonePlacement
+                ? BuildBalancedRingLetters(playerLetters, neutralZones, minNeutralZonesBetweenPlayers: 0)
+                : playerLetters.Concat(neutralLetters).ToList();
             var zones = new List<Zone>();
             var connections = new List<Connection>();
 
@@ -634,8 +936,7 @@ namespace Olden_Era___Template_Editor.Services
         private static Variant BuildVariantChain(GeneratorSettings settings, List<string> playerLetters, List<NeutralZonePlan> neutralZones, GenerationTuning tuning)
         {
             var neutralByLetter = neutralZones.ToDictionary(zone => zone.Letter);
-            var neutralLetters = neutralZones.Select(zone => zone.Letter).ToList();
-            var orderedLetters = BuildOrderedLetters(settings, playerLetters, neutralLetters, isRing: false);
+            var orderedLetters = BuildOrderedLetters(settings, playerLetters, neutralZones, isRing: false);
             int count = orderedLetters.Count;
             bool isolate = settings.NoDirectPlayerConnections && playerLetters.Count > 1;
 
@@ -704,7 +1005,9 @@ namespace Olden_Era___Template_Editor.Services
             // If there are fewer neutrals than needed, we wrap around (multiple players share a neutral).
             // Requires at least 1 neutral zone.
             var neutralByLetter = neutralZones.ToDictionary(zone => zone.Letter);
-            var neutrals = neutralZones.Select(zone => zone.Letter).ToList();
+            var neutrals = settings.ExperimentalBalancedZonePlacement
+                ? BuildBalancedNeutralRing(neutralZones, playerLetters.Count)
+                : neutralZones.Select(zone => zone.Letter).ToList();
 
             int p = playerLetters.Count;
             int n = neutrals.Count;
@@ -717,29 +1020,45 @@ namespace Olden_Era___Template_Editor.Services
                 neutralRingConns[i] = $"NRing-{neutrals[i]}-{neutrals[next]}";
             }
 
-            var zones = new List<Zone>();
-            var connections = new List<Connection>();
-
-            // Build neutral zones — each connects to its two ring neighbours.
-            for (int i = 0; i < n; i++)
-            {
-                int prev = (i - 1 + n) % n;
-                string[] nConns = n > 1
-                    ? new[] { neutralRingConns[prev], neutralRingConns[i] }.Distinct().ToArray()
-                    : [];
-                zones.Add(BuildNeutralZone(neutralByLetter[neutrals[i]], nConns, settings.NeutralZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
-            }
-
-            // Build player zones — each connects to two neutrals (evenly distributed).
+            var spokeConnsByPlayer = playerLetters.ToDictionary(letter => letter, _ => new List<string>());
+            var spokeConnsByNeutral = neutrals.ToDictionary(letter => letter, _ => new List<string>());
             for (int i = 0; i < p; i++)
             {
                 // Spread players across neutral ring evenly.
                 int n1 = (i * n / p) % n;
                 int n2 = ((i * n / p) + 1) % n;
 
-                var spokeConns = new List<string> { $"Web-{playerLetters[i]}-{neutrals[n1]}" };
+                AddSpoke(playerLetters[i], neutrals[n1]);
                 if (n1 != n2)
-                    spokeConns.Add($"Web-{playerLetters[i]}-{neutrals[n2]}");
+                    AddSpoke(playerLetters[i], neutrals[n2]);
+            }
+
+            var zones = new List<Zone>();
+            var connections = new List<Connection>();
+
+            // Build neutral zones. Each neutral receives its ring and player-spoke endpoints.
+            for (int i = 0; i < n; i++)
+            {
+                int prev = (i - 1 + n) % n;
+                var neutralConns = new List<string>();
+                if (n > 1)
+                {
+                    neutralConns.Add(neutralRingConns[prev]);
+                    neutralConns.Add(neutralRingConns[i]);
+                }
+
+                neutralConns.AddRange(spokeConnsByNeutral[neutrals[i]]);
+                string[] nConns = neutralConns.Distinct().ToArray();
+                Zone neutralZone = BuildNeutralZone(neutralByLetter[neutrals[i]], nConns, settings.NeutralZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning);
+                if (neutralByLetter[neutrals[i]].CastleCount == 0)
+                    neutralZone.Roads = BuildConnectorZoneRoads(nConns, settings.GenerateRoads);
+                zones.Add(neutralZone);
+            }
+
+            // Build player zones — each connects to two neutrals (evenly distributed).
+            for (int i = 0; i < p; i++)
+            {
+                var spokeConns = spokeConnsByPlayer[playerLetters[i]];
 
                 zones.Add(BuildSpawnZone(playerLetters[i], $"Player{i + 1}", spokeConns.ToArray(), settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.PlayerZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
 
@@ -795,8 +1114,14 @@ namespace Olden_Era___Template_Editor.Services
             bool isolateWeb = settings.NoDirectPlayerConnections && playerLetters.Count > 1;
             if (isolateWeb) EnsurePlayerZonesConnected(playerLetters, zones, connections, tuning);
 
-            var allZoneLettersOrdered = neutrals.Concat(playerLetters).ToList();
             return MakeVariant(playerLetters, playerLetters[0], zones.Count, zones, connections);
+
+            void AddSpoke(string playerLetter, string neutralLetter)
+            {
+                string connName = $"Web-{playerLetter}-{neutralLetter}";
+                spokeConnsByPlayer[playerLetter].Add(connName);
+                spokeConnsByNeutral[neutralLetter].Add(connName);
+            }
         }
 
         // ── Hub zone (only used by Hub & Spoke topology) ─────────────────────────
@@ -914,7 +1239,7 @@ namespace Olden_Era___Template_Editor.Services
         {
             Orientation = new Orientation
             {
-                ZeroAngleZone = playerLetters.Count > 0 ? $"Spawn-{firstLetter}" : $"Neutral-{firstLetter}",
+                ZeroAngleZone = playerLetters.Contains(firstLetter) ? $"Spawn-{firstLetter}" : $"Neutral-{firstLetter}",
                 BaseAngleMin = 45,
                 BaseAngleMax = 45,
                 RandomAngleAmplitude = 360,
@@ -1293,6 +1618,31 @@ namespace Olden_Era___Template_Editor.Services
                 roads.Add(PlainRoad(MainObjectEndpoint("0"), MandatoryContentEndpoint("name_remote_foothold_1")));
             foreach (var rc in ringConns)
                 roads.Add(PlainRoad(MainObjectEndpoint("0"), ConnectionEndpoint(rc)));
+            return roads;
+        }
+
+        private static List<Road> BuildConnectorZoneRoads(string[] connectionNames, bool generateRoads)
+        {
+            var roads = new List<Road>();
+            if (!generateRoads) return roads;
+
+            var distinctConnections = connectionNames
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Distinct()
+                .ToList();
+
+            if (distinctConnections.Count == 1)
+            {
+                string connectionName = distinctConnections[0];
+                roads.Add(PlainRoad(ConnectionEndpoint(connectionName), ConnectionEndpoint(connectionName)));
+                return roads;
+            }
+
+            string? anchor = distinctConnections.FirstOrDefault();
+            if (anchor == null) return roads;
+
+            foreach (string connectionName in distinctConnections.Skip(1))
+                roads.Add(PlainRoad(ConnectionEndpoint(anchor), ConnectionEndpoint(connectionName)));
             return roads;
         }
 

--- a/Olden Era - Template Editor/Services/TemplateGenerator.cs
+++ b/Olden Era - Template Editor/Services/TemplateGenerator.cs
@@ -30,8 +30,12 @@ namespace Olden_Era___Template_Editor.Services
             var neutralLetters = ZoneLetters.Skip(settings.PlayerCount).Take(neutralCount).ToList();
 
             int totalZones = settings.PlayerCount + neutralCount;
-            double contentScale = ComputeContentScale(settings.MapSize, totalZones);
-            double densityMult  = settings.ContentDensityPercent / 100.0;
+            var tuning = new GenerationTuning(
+                ComputeContentScale(settings.MapSize, totalZones),
+                settings.ResourceDensityPercent / 100.0,
+                settings.StructureDensityPercent / 100.0,
+                settings.NeutralStackStrengthPercent / 100.0,
+                settings.BorderGuardStrengthPercent / 100.0);
 
             var template = new RmgTemplate
             {
@@ -42,7 +46,7 @@ namespace Olden_Era___Template_Editor.Services
                 SizeX = settings.MapSize,
                 SizeZ = settings.MapSize,
                 GameRules = BuildGameRules(settings),
-                Variants = [BuildVariant(settings, playerLetters, neutralLetters, contentScale, densityMult)],
+                Variants = [BuildVariant(settings, playerLetters, neutralLetters, tuning)],
                 ZoneLayouts = BuildZoneLayouts(),
                 MandatoryContent = BuildAllMandatoryContent(playerLetters, neutralLetters, settings),
                 ContentCountLimits = BuildAllContentCountLimits(),
@@ -90,6 +94,31 @@ namespace Olden_Era___Template_Editor.Services
             }
         };
 
+        private readonly record struct GenerationTuning(
+            double ContentScale,
+            double ResourceDensityMultiplier,
+            double StructureDensityMultiplier,
+            double NeutralStackStrengthMultiplier,
+            double BorderGuardStrengthMultiplier);
+
+        private static int ScaleValue(double value, double multiplier) =>
+            Math.Max(0, (int)(value * multiplier));
+
+        private static int ScaleStructureValue(double value, GenerationTuning tuning) =>
+            ScaleValue(value, tuning.StructureDensityMultiplier);
+
+        private static int ScaleResourceValue(double value, GenerationTuning tuning) =>
+            ScaleValue(value, tuning.ResourceDensityMultiplier);
+
+        private static int ScaleNeutralGuardValue(int value, GenerationTuning tuning) =>
+            ScaleValue(value, tuning.NeutralStackStrengthMultiplier);
+
+        private static int ScaleBorderGuardValue(int value, GenerationTuning tuning) =>
+            ScaleValue(value, tuning.BorderGuardStrengthMultiplier);
+
+        private static double ScaleGuardMultiplier(double value, GenerationTuning tuning) =>
+            Math.Round(value * tuning.NeutralStackStrengthMultiplier, 3, MidpointRounding.AwayFromZero);
+
         // ── Content scale ────────────────────────────────────────────────────────
 
         /// <summary>
@@ -106,7 +135,7 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Variant ──────────────────────────────────────────────────────────────
 
-        private static Variant BuildVariant(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, double contentScale, double densityMult)
+        private static Variant BuildVariant(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
         {
             // Shuffle player letters so Player 1 is not always at the same geometric position.
             var rng = new Random();
@@ -115,17 +144,17 @@ namespace Olden_Era___Template_Editor.Services
 
             return settings.Topology switch
             {
-                MapTopology.HubAndSpoke => BuildVariantHubAndSpoke(settings, playerLetters, neutralLetters, contentScale, densityMult),
-                MapTopology.Chain       => BuildVariantChain(settings, playerLetters, neutralLetters, contentScale, densityMult),
-                MapTopology.SharedWeb   => BuildVariantSharedWeb(settings, playerLetters, neutralLetters, contentScale, densityMult),
-                MapTopology.Random      => BuildVariantRandom(settings, playerLetters, neutralLetters, contentScale, densityMult),
-                _                       => BuildVariantDefault(settings, playerLetters, neutralLetters, contentScale, densityMult),
+                MapTopology.HubAndSpoke => BuildVariantHubAndSpoke(settings, playerLetters, neutralLetters, tuning),
+                MapTopology.Chain       => BuildVariantChain(settings, playerLetters, neutralLetters, tuning),
+                MapTopology.SharedWeb   => BuildVariantSharedWeb(settings, playerLetters, neutralLetters, tuning),
+                MapTopology.Random      => BuildVariantRandom(settings, playerLetters, neutralLetters, tuning),
+                _                       => BuildVariantDefault(settings, playerLetters, neutralLetters, tuning),
             };
         }
 
         // ── Topology: Default (Ring) ──────────────────────────────────────────────
 
-        private static Variant BuildVariantDefault(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, double contentScale, double densityMult)
+        private static Variant BuildVariantDefault(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
         {
             var orderedLetters = playerLetters.Concat(neutralLetters).ToList();
             int outerCount = orderedLetters.Count;
@@ -156,23 +185,23 @@ namespace Olden_Era___Template_Editor.Services
 
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, contentScale, densityMult));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(letter, myConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, contentScale, densityMult));
+                    zones.Add(BuildNeutralZone(letter, myConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             var connections = new List<Connection>();
-            connections.AddRange(BuildRingConnections(playerLetters, orderedLetters, isolate));
+            connections.AddRange(BuildRingConnections(playerLetters, orderedLetters, tuning, isolate));
             if (settings.RandomPortals)
-                connections.AddRange(BuildRandomPortalConnections(playerLetters, orderedLetters));
+                connections.AddRange(BuildRandomPortalConnections(playerLetters, orderedLetters, tuning));
 
-            if (isolate) EnsurePlayerZonesConnected(playerLetters, zones, connections);
+            if (isolate) EnsurePlayerZonesConnected(playerLetters, zones, connections, tuning);
             return MakeVariant(playerLetters, orderedLetters[0], outerCount, zones, connections);
         }
 
         // ── Topology: Random Proximity ────────────────────────────────────────────
 
-        private static Variant BuildVariantRandom(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, double contentScale, double densityMult)
+        private static Variant BuildVariantRandom(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
         {
             var rng = new Random();
             // Shuffle zones so player/neutral order is random.
@@ -216,7 +245,7 @@ namespace Olden_Era___Template_Editor.Services
                     GuardZone = fromZone,
                     GuardEscape = false,
                     SimTurnSquad = true,
-                    GuardValue = 30000,
+                    GuardValue = ScaleBorderGuardValue(30000, tuning),
                     GuardWeeklyIncrement = 0.15,
                     GuardMatchGroup = $"rnd_guard_{fromLetter}_{toLetter}"
                 });
@@ -229,15 +258,15 @@ namespace Olden_Era___Template_Editor.Services
                 var myConns = connsByZone[i].ToArray();
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, contentScale, densityMult));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(letter, myConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, contentScale, densityMult));
+                    zones.Add(BuildNeutralZone(letter, myConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             if (settings.RandomPortals)
-                connections.AddRange(BuildRandomPortalConnections(playerLetters, allLetters));
+                connections.AddRange(BuildRandomPortalConnections(playerLetters, allLetters, tuning));
 
-            if (isolate) EnsurePlayerZonesConnected(playerLetters, zones, connections);
+            if (isolate) EnsurePlayerZonesConnected(playerLetters, zones, connections, tuning);
             return MakeVariant(playerLetters, allLetters[0], count, zones, connections);
         }
 
@@ -323,7 +352,7 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Topology: Hub & Spoke ─────────────────────────────────────────────────
 
-        private static Variant BuildVariantHubAndSpoke(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, double contentScale, double densityMult)
+        private static Variant BuildVariantHubAndSpoke(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
         {
             // A central "Hub" zone connects to every outer zone.
             // Outer zones are players + neutrals arranged around the hub.
@@ -333,7 +362,7 @@ namespace Olden_Era___Template_Editor.Services
 
             // Hub zone (neutral, no castle, high loot).
             var hubConns = outerLetters.Select(l => $"Hub-{l}").ToArray();
-            zones.Add(BuildHubZone(hubConns, contentScale, densityMult));
+            zones.Add(BuildHubZone(hubConns, tuning));
 
             // Outer zones each connect only to the hub.
             for (int i = 0; i < outerLetters.Count; i++)
@@ -342,9 +371,9 @@ namespace Olden_Era___Template_Editor.Services
                 var spokeConns = new[] { $"Hub-{letter}" };
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", spokeConns, settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, contentScale, densityMult));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", spokeConns, settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(letter, spokeConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, contentScale, densityMult));
+                    zones.Add(BuildNeutralZone(letter, spokeConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             // Hub → each outer zone: Direct guarded connections (multiple per zone like JCC).
@@ -361,7 +390,7 @@ namespace Olden_Era___Template_Editor.Services
                     GuardZone = "Hub",
                     GuardEscape = false,
                     SimTurnSquad = true,
-                    GuardValue = 30000,
+                    GuardValue = ScaleBorderGuardValue(30000, tuning),
                     GuardWeeklyIncrement = 0.15,
                     GuardMatchGroup = $"hub_guard_{letter}"
                 });
@@ -388,14 +417,14 @@ namespace Olden_Era___Template_Editor.Services
             }
 
             if (settings.RandomPortals)
-                connections.AddRange(BuildRandomPortalConnections(playerLetters, outerLetters));
+                connections.AddRange(BuildRandomPortalConnections(playerLetters, outerLetters, tuning));
 
             return MakeVariant(playerLetters, outerLetters[0], outerLetters.Count + 1, zones, connections);
         }
 
         // ── Topology: Chain ───────────────────────────────────────────────────────
 
-        private static Variant BuildVariantChain(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, double contentScale, double densityMult)
+        private static Variant BuildVariantChain(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
         {
             var orderedLetters = playerLetters.Concat(neutralLetters).ToList();
             int count = orderedLetters.Count;
@@ -422,9 +451,9 @@ namespace Olden_Era___Template_Editor.Services
 
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns.ToArray(), settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, contentScale, densityMult));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns.ToArray(), settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(letter, myConns.ToArray(), settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, contentScale, densityMult));
+                    zones.Add(BuildNeutralZone(letter, myConns.ToArray(), settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             var connections = new List<Connection>();
@@ -444,22 +473,22 @@ namespace Olden_Era___Template_Editor.Services
                     GuardZone = fromZone,
                     GuardEscape = false,
                     SimTurnSquad = true,
-                    GuardValue = 30000,
+                    GuardValue = ScaleBorderGuardValue(30000, tuning),
                     GuardWeeklyIncrement = 0.15,
                     GuardMatchGroup = $"chain_guard_{fromLetter}_{toLetter}"
                 });
             }
 
             if (settings.RandomPortals)
-                connections.AddRange(BuildRandomPortalConnections(playerLetters, orderedLetters));
+                connections.AddRange(BuildRandomPortalConnections(playerLetters, orderedLetters, tuning));
 
-            if (isolate) EnsurePlayerZonesConnected(playerLetters, zones, connections);
+            if (isolate) EnsurePlayerZonesConnected(playerLetters, zones, connections, tuning);
             return MakeVariant(playerLetters, orderedLetters[0], count, zones, connections);
         }
 
         // ── Topology: Shared Web ──────────────────────────────────────────────────
 
-        private static Variant BuildVariantSharedWeb(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, double contentScale, double densityMult)
+        private static Variant BuildVariantSharedWeb(GeneratorSettings settings, List<string> playerLetters, List<string> neutralLetters, GenerationTuning tuning)
         {
             // Each player connects to two neutral zones.
             // Neutral zones are arranged in a ring connecting all players.
@@ -490,7 +519,7 @@ namespace Olden_Era___Template_Editor.Services
                 string[] nConns = n > 1
                     ? new[] { neutralRingConns[prev], neutralRingConns[i] }.Distinct().ToArray()
                     : [];
-                zones.Add(BuildNeutralZone(neutrals[i], nConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, contentScale, densityMult));
+                zones.Add(BuildNeutralZone(neutrals[i], nConns, settings.NeutralZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             // Build player zones — each connects to two neutrals (evenly distributed).
@@ -504,7 +533,7 @@ namespace Olden_Era___Template_Editor.Services
                 if (n1 != n2)
                     spokeConns.Add($"Web-{playerLetters[i]}-{neutrals[n2]}");
 
-                zones.Add(BuildSpawnZone(playerLetters[i], $"Player{i + 1}", spokeConns.ToArray(), settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, contentScale, densityMult));
+                zones.Add(BuildSpawnZone(playerLetters[i], $"Player{i + 1}", spokeConns.ToArray(), settings.PlayerZoneCastles, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
 
                 // Player → neutral Direct connections.
                 foreach (var connName in spokeConns)
@@ -520,7 +549,7 @@ namespace Olden_Era___Template_Editor.Services
                         GuardZone = neutralZone,
                         GuardEscape = false,
                         SimTurnSquad = true,
-                        GuardValue = 30000,
+                        GuardValue = ScaleBorderGuardValue(30000, tuning),
                         GuardWeeklyIncrement = 0.15,
                         GuardMatchGroup = $"web_guard_{playerLetters[i]}_{neutralLetter}"
                     });
@@ -542,7 +571,7 @@ namespace Olden_Era___Template_Editor.Services
                         GuardZone = $"Neutral-{neutrals[i]}",
                         GuardEscape = false,
                         SimTurnSquad = true,
-                        GuardValue = 20000,
+                        GuardValue = ScaleBorderGuardValue(20000, tuning),
                         GuardWeeklyIncrement = 0.15,
                         GuardMatchGroup = $"nring_guard_{neutrals[i]}_{neutrals[next]}"
                     });
@@ -552,11 +581,11 @@ namespace Olden_Era___Template_Editor.Services
             if (settings.RandomPortals)
             {
                 var allLetters = playerLetters.Concat(neutrals).ToList();
-                connections.AddRange(BuildRandomPortalConnections(playerLetters, allLetters));
+                connections.AddRange(BuildRandomPortalConnections(playerLetters, allLetters, tuning));
             }
 
             bool isolateWeb = settings.NoDirectPlayerConnections && playerLetters.Count > 1;
-            if (isolateWeb) EnsurePlayerZonesConnected(playerLetters, zones, connections);
+            if (isolateWeb) EnsurePlayerZonesConnected(playerLetters, zones, connections, tuning);
 
             var allZoneLettersOrdered = neutrals.Concat(playerLetters).ToList();
             return MakeVariant(playerLetters, playerLetters[0], zones.Count, zones, connections);
@@ -564,14 +593,14 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Hub zone (only used by Hub & Spoke topology) ─────────────────────────
 
-        private static Zone BuildHubZone(string[] spokeConns, double contentScale, double densityMult) => new()
+        private static Zone BuildHubZone(string[] spokeConns, GenerationTuning tuning) => new()
         {
             Name = "Hub",
             Size = 1.0,
             Layout = "zone_layout_spawns",
             GuardCutoffValue = 2000,
             GuardRandomization = 0.05,
-            GuardMultiplier = 1.5,
+            GuardMultiplier = ScaleGuardMultiplier(1.5, tuning),
             GuardWeeklyIncrement = 0.20,
             GuardReactionDistribution = [0, 10, 10, 20, 10, 0],
             DiplomacyModifier = -0.5,
@@ -580,12 +609,12 @@ namespace Olden_Era___Template_Editor.Services
             ResourcesContentPool = ["content_pool_general_resources_start_zone_rich"],
             MandatoryContent = [],
             ContentCountLimits = BuildSideContentLimits(),
-            GuardedContentValue = (int)(300000 * contentScale * densityMult),
-            GuardedContentValuePerArea = (int)(2400 * Math.Sqrt(contentScale) * densityMult),
-            UnguardedContentValue = (int)(50000 * contentScale * densityMult),
-            UnguardedContentValuePerArea = (int)(600 * Math.Sqrt(contentScale) * densityMult),
-            ResourcesValue = (int)(80000 * contentScale * densityMult),
-            ResourcesValuePerArea = (int)(600 * Math.Sqrt(contentScale) * densityMult),
+            GuardedContentValue = ScaleStructureValue(300000 * tuning.ContentScale, tuning),
+            GuardedContentValuePerArea = ScaleStructureValue(2400 * Math.Sqrt(tuning.ContentScale), tuning),
+            UnguardedContentValue = ScaleStructureValue(50000 * tuning.ContentScale, tuning),
+            UnguardedContentValuePerArea = ScaleStructureValue(600 * Math.Sqrt(tuning.ContentScale), tuning),
+            ResourcesValue = ScaleResourceValue(80000 * tuning.ContentScale, tuning),
+            ResourcesValuePerArea = ScaleResourceValue(600 * Math.Sqrt(tuning.ContentScale), tuning),
             MainObjects = [],
             ZoneBiome = new BiomeSelector { Type = "MatchMainObject", Args = ["0"] },
             ContentBiome = new BiomeSelector { Type = "MatchMainObject", Args = ["0"] },
@@ -602,7 +631,7 @@ namespace Olden_Era___Template_Editor.Services
         /// This method adds a minimal direct player–player fallback connection for each such zone.
         /// </summary>
         private static void EnsurePlayerZonesConnected(
-            List<string> playerLetters, List<Zone> zones, List<Connection> connections)
+            List<string> playerLetters, List<Zone> zones, List<Connection> connections, GenerationTuning tuning)
         {
             if (playerLetters.Count < 2) return;
 
@@ -652,7 +681,7 @@ namespace Olden_Era___Template_Editor.Services
                     GuardZone = $"Spawn-{letter}",
                     GuardEscape = false,
                     SimTurnSquad = true,
-                    GuardValue = 30000,
+                    GuardValue = ScaleBorderGuardValue(30000, tuning),
                     GuardWeeklyIncrement = 0.15,
                     GuardMatchGroup = $"fallback_guard_{fallbackName}"
                 });
@@ -698,7 +727,7 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Spawn zone ───────────────────────────────────────────────────────────
 
-        private static Zone BuildSpawnZone(string letter, string player, string[] ringConns, int castleCount, bool spawnFootholds, bool generateRoads, double contentScale, double densityMult)
+        private static Zone BuildSpawnZone(string letter, string player, string[] ringConns, int castleCount, bool spawnFootholds, bool generateRoads, GenerationTuning tuning)
         {
             // Index 0 = Spawn (player town), indices 1..castleCount = extra same-faction cities.
             var mainObjects = new List<MainObject>
@@ -709,7 +738,7 @@ namespace Olden_Era___Template_Editor.Services
                     Spawn = player,
                     RemoveGuardIfHasOwner = true,
                     GuardChance = 0.5,
-                    GuardValue = 5000,
+                    GuardValue = ScaleNeutralGuardValue(5000, tuning),
                     GuardWeeklyIncrement = 0.10,
                     BuildingsConstructionSid = "default_buildings_construction",
                     Placement = "Uniform",
@@ -724,7 +753,7 @@ namespace Olden_Era___Template_Editor.Services
                     Type = "City",
                     Faction = new TypedSelector { Type = "Random", Args = [] },
                     GuardChance = 0.5,
-                    GuardValue = 2500,
+                    GuardValue = ScaleNeutralGuardValue(2500, tuning),
                     GuardWeeklyIncrement = 0.10,
                     BuildingsConstructionSid = "poor_buildings_construction",
                     Placement = "Uniform",
@@ -739,7 +768,7 @@ namespace Olden_Era___Template_Editor.Services
                 Layout = "zone_layout_spawns",
                 GuardCutoffValue = 2000,
                 GuardRandomization = 0.05,
-                GuardMultiplier = 1.0,
+                GuardMultiplier = ScaleGuardMultiplier(1.0, tuning),
                 GuardWeeklyIncrement = 0.20,
                 GuardReactionDistribution = [60, 20, 10, 10, 2, 0],
                 DiplomacyModifier = -0.5,
@@ -748,12 +777,12 @@ namespace Olden_Era___Template_Editor.Services
                 ResourcesContentPool = ["content_pool_general_resources_start_zone_rich"],
                 MandatoryContent = [$"mandatory_content_side_{letter}"],
                 ContentCountLimits = BuildSideContentLimits(),
-                GuardedContentValue = (int)(200000 * contentScale * densityMult),
-                GuardedContentValuePerArea = (int)(2000 * Math.Sqrt(contentScale) * densityMult),
-                UnguardedContentValue = (int)(50000 * contentScale * densityMult),
-                UnguardedContentValuePerArea = (int)(400 * Math.Sqrt(contentScale) * densityMult),
-                ResourcesValue = (int)(80000 * contentScale * densityMult),
-                ResourcesValuePerArea = (int)(600 * Math.Sqrt(contentScale) * densityMult),
+                GuardedContentValue = ScaleStructureValue(200000 * tuning.ContentScale, tuning),
+                GuardedContentValuePerArea = ScaleStructureValue(2000 * Math.Sqrt(tuning.ContentScale), tuning),
+                UnguardedContentValue = ScaleStructureValue(50000 * tuning.ContentScale, tuning),
+                UnguardedContentValuePerArea = ScaleStructureValue(400 * Math.Sqrt(tuning.ContentScale), tuning),
+                ResourcesValue = ScaleResourceValue(80000 * tuning.ContentScale, tuning),
+                ResourcesValuePerArea = ScaleResourceValue(600 * Math.Sqrt(tuning.ContentScale), tuning),
                 MainObjects = mainObjects,
                 ZoneBiome = new BiomeSelector { Type = "MatchMainObject", Args = ["0"] },
                 ContentBiome = new BiomeSelector { Type = "MatchMainObject", Args = ["0"] },
@@ -765,7 +794,7 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Neutral zone ─────────────────────────────────────────────────────────
 
-        private static Zone BuildNeutralZone(string letter, string[] ringConns, int castleCount, bool spawnFootholds, bool generateRoads, double contentScale, double densityMult)
+        private static Zone BuildNeutralZone(string letter, string[] ringConns, int castleCount, bool spawnFootholds, bool generateRoads, GenerationTuning tuning)
         {
             // Index 0 = primary neutral city; indices 1..castleCount-1 = extra neutral cities.
             // All cities use FromList [] (neutral faction, not biome-matched).
@@ -775,7 +804,7 @@ namespace Olden_Era___Template_Editor.Services
                 {
                     Type = "City",
                     GuardChance = 0.5,
-                    GuardValue = 10000,
+                    GuardValue = ScaleNeutralGuardValue(10000, tuning),
                     GuardWeeklyIncrement = 0.10,
                     BuildingsConstructionSid = "rich_buildings_construction",
                     Faction = new TypedSelector { Type = "FromList", Args = [] },
@@ -789,7 +818,7 @@ namespace Olden_Era___Template_Editor.Services
                 {
                     Type = "City",
                     GuardChance = 0.5,
-                    GuardValue = 5000,
+                    GuardValue = ScaleNeutralGuardValue(5000, tuning),
                     GuardWeeklyIncrement = 0.10,
                     BuildingsConstructionSid = "poor_buildings_construction",
                     Faction = new TypedSelector { Type = "FromList", Args = [] },
@@ -805,7 +834,7 @@ namespace Olden_Era___Template_Editor.Services
                 Layout = "zone_layout_spawns",
                 GuardCutoffValue = 2000,
                 GuardRandomization = 0.05,
-                GuardMultiplier = 1.3,
+                GuardMultiplier = ScaleGuardMultiplier(1.3, tuning),
                 GuardWeeklyIncrement = 0.20,
                 GuardReactionDistribution = [0, 10, 10, 10, 10, 0],
                 DiplomacyModifier = -0.5,
@@ -814,12 +843,12 @@ namespace Olden_Era___Template_Editor.Services
                 ResourcesContentPool = ["content_pool_general_resources_start_zone_rich"],
                 MandatoryContent = [$"mandatory_content_neutral_{letter}"],
                 ContentCountLimits = BuildSideContentLimits(),
-                GuardedContentValue = (int)(260000 * contentScale * densityMult),
-                GuardedContentValuePerArea = (int)(2400 * Math.Sqrt(contentScale) * densityMult),
-                UnguardedContentValue = (int)(40000 * contentScale * densityMult),
-                UnguardedContentValuePerArea = (int)(320 * Math.Sqrt(contentScale) * densityMult),
-                ResourcesValue = (int)(60000 * contentScale * densityMult),
-                ResourcesValuePerArea = (int)(480 * Math.Sqrt(contentScale) * densityMult),
+                GuardedContentValue = ScaleStructureValue(260000 * tuning.ContentScale, tuning),
+                GuardedContentValuePerArea = ScaleStructureValue(2400 * Math.Sqrt(tuning.ContentScale), tuning),
+                UnguardedContentValue = ScaleStructureValue(40000 * tuning.ContentScale, tuning),
+                UnguardedContentValuePerArea = ScaleStructureValue(320 * Math.Sqrt(tuning.ContentScale), tuning),
+                ResourcesValue = ScaleResourceValue(60000 * tuning.ContentScale, tuning),
+                ResourcesValuePerArea = ScaleResourceValue(480 * Math.Sqrt(tuning.ContentScale), tuning),
                 MainObjects = mainObjects,
                 ZoneBiome = castleCount > 0
                     ? new BiomeSelector { Type = "MatchMainObject", Args = ["0"] }
@@ -843,7 +872,7 @@ namespace Olden_Era___Template_Editor.Services
         /// When <paramref name="isolatePlayers"/> is true, player–player adjacent pairs are skipped.
         /// </summary>
         private static IEnumerable<Connection> BuildRingConnections(
-            List<string> playerLetters, List<string> orderedLetters, bool isolatePlayers = false)
+            List<string> playerLetters, List<string> orderedLetters, GenerationTuning tuning, bool isolatePlayers = false)
         {
             int count = orderedLetters.Count;
             if (count < 2) yield break;
@@ -869,7 +898,7 @@ namespace Olden_Era___Template_Editor.Services
                     GuardZone = fromZone,
                     GuardEscape = false,
                     SimTurnSquad = true,
-                    GuardValue = 30000,
+                    GuardValue = ScaleBorderGuardValue(30000, tuning),
                     GuardWeeklyIncrement = 0.15,
                     GuardMatchGroup = $"ring_guard_{fromLetter}_{toLetter}"
                 };
@@ -882,7 +911,7 @@ namespace Olden_Era___Template_Editor.Services
         /// that does NOT lead to its immediate ring neighbours.
         /// </summary>
         private static IEnumerable<Connection> BuildRandomPortalConnections(
-            List<string> playerLetters, List<string> orderedLetters)
+            List<string> playerLetters, List<string> orderedLetters, GenerationTuning tuning)
         {
             int count = orderedLetters.Count;
             if (count < 2) yield break; // Need at least 2 zones for a portal.
@@ -912,7 +941,7 @@ namespace Olden_Era___Template_Editor.Services
                     PortalPlacementRulesTo   = [new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = 0.1, TargetMax = 0.3, Weight = 2 }],
                     Road = true,
                     GuardEscape = false,
-                    GuardValue = 25000,
+                    GuardValue = ScaleBorderGuardValue(25000, tuning),
                     GuardWeeklyIncrement = 0.15
                 };
             }

--- a/Olden Era - Template Editor/Services/TemplateGenerator.cs
+++ b/Olden Era - Template Editor/Services/TemplateGenerator.cs
@@ -13,6 +13,11 @@ namespace Olden_Era___Template_Editor.Services
     {
         // Each player zone gets 5 guard connections to the center (same as JCC).
         private const int ConnectionsPerZone = 5;
+        private const double DefaultGuardRandomization = 0.05;
+        private const string SpawnLayoutName = "zone_layout_spawns";
+        private const string SideLayoutName = "zone_layout_sides";
+        private const string TreasureLayoutName = "zone_layout_treasure_zone";
+        private const string CenterLayoutName = "zone_layout_center";
 
         // Labels used to name zones, up to the advanced-mode maximum of 32 total zones.
         private static readonly string[] ZoneLetters =
@@ -40,17 +45,22 @@ namespace Olden_Era___Template_Editor.Services
                 settings.ResourceDensityPercent / 100.0,
                 settings.StructureDensityPercent / 100.0,
                 settings.NeutralStackStrengthPercent / 100.0,
-                settings.BorderGuardStrengthPercent / 100.0);
+                settings.BorderGuardStrengthPercent / 100.0,
+                EffectiveGuardRandomization(settings));
+
+            string effectiveVictoryCondition = settings.AdvancedMode
+                ? settings.VictoryCondition
+                : "win_condition_1";
 
             var template = new RmgTemplate
             {
                 Name = settings.TemplateName,
                 GameMode = settings.GameMode,
                 Description = "custom_generated_template",
-                DisplayWinCondition = settings.VictoryCondition,
+                DisplayWinCondition = effectiveVictoryCondition,
                 SizeX = settings.MapSize,
                 SizeZ = settings.MapSize,
-                GameRules = BuildGameRules(settings),
+                GameRules = BuildGameRules(settings, effectiveVictoryCondition),
                 Variants = [BuildVariant(settings, playerLetters, neutralZones, tuning)],
                 ZoneLayouts = BuildZoneLayouts(),
                 MandatoryContent = BuildAllMandatoryContent(playerLetters, neutralZones, settings),
@@ -65,6 +75,7 @@ namespace Olden_Era___Template_Editor.Services
         private sealed record NeutralZonePlan(string Letter, NeutralZoneQuality Quality, int CastleCount);
 
         private sealed record NeutralZoneProfile(
+            string Layout,
             double GuardMultiplier,
             string GuardedContentPool,
             string UnguardedContentPool,
@@ -123,15 +134,15 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Game rules ───────────────────────────────────────────────────────────
 
-        private static GameRules BuildGameRules(GeneratorSettings settings) => new()
+        private static GameRules BuildGameRules(GeneratorSettings settings, string effectiveVictoryCondition) => new()
         {
             HeroCountMin = settings.HeroCountMin,
             HeroCountMax = settings.HeroCountMax,
             HeroCountIncrement = settings.HeroCountIncrement,
             HeroHireBan = false,
             EncounterHoles = false,
-            FactionLawsExpModifier = 1.0,
-            AstrologyExpModifier = 1.0,
+            FactionLawsExpModifier = settings.AdvancedMode ? PercentToModifier(settings.FactionLawsExpPercent) : 1.0,
+            AstrologyExpModifier = settings.AdvancedMode ? PercentToModifier(settings.AstrologyExpPercent) : 1.0,
             Bonuses =
             [
                 new Bonus
@@ -142,28 +153,93 @@ namespace Olden_Era___Template_Editor.Services
                     Parameters = ["movementBonus", "0"]
                 }
             ],
-            WinConditions = new WinConditions
+            WinConditions = settings.AdvancedMode
+                ? BuildAdvancedWinConditions(settings, effectiveVictoryCondition)
+                : BuildDefaultWinConditions()
+        };
+
+        private static double PercentToModifier(int percent) =>
+            Math.Round(Math.Clamp(percent, 25, 200) / 100.0, 2, MidpointRounding.AwayFromZero);
+
+        private static WinConditions BuildDefaultWinConditions() => new()
+        {
+            Classic = true,
+            Desertion = true,
+            DesertionDay = 3,
+            DesertionValue = 3000,
+            HeroLighting = false,
+            HeroLightingDay = 1,
+            LostStartCity = false,
+            LostStartCityDay = 3,
+            LostStartHero = false,
+            CityHold = false,
+            CityHoldDays = 6
+        };
+
+        private static WinConditions BuildAdvancedWinConditions(GeneratorSettings settings, string effectiveVictoryCondition)
+        {
+            bool useLostStartCity = settings.LostStartCity || effectiveVictoryCondition == "win_condition_3";
+            bool useCityHold = settings.CityHold || effectiveVictoryCondition == "win_condition_5";
+            bool useGladiator = settings.GladiatorArena || effectiveVictoryCondition == "win_condition_4";
+            bool useTournament = settings.Tournament || effectiveVictoryCondition == "win_condition_6";
+
+            var winConditions = new WinConditions
             {
                 Classic = true,
                 Desertion = true,
                 DesertionDay = 3,
                 DesertionValue = 3000,
-                HeroLighting = false,
+                HeroLighting = true,
                 HeroLightingDay = 1,
-                LostStartCity = false,
-                LostStartCityDay = 3,
-                LostStartHero = false,
-                CityHold = false,
-                CityHoldDays = 6
+                LostStartCity = useLostStartCity,
+                LostStartCityDay = Math.Clamp(settings.LostStartCityDay, 1, 30),
+                LostStartHero = settings.LostStartHero || useGladiator || useTournament,
+                CityHold = useCityHold,
+                CityHoldDays = Math.Clamp(settings.CityHoldDays, 1, 30)
+            };
+
+            if (useGladiator)
+            {
+                winConditions.GladiatorArena = true;
+                winConditions.GladiatorArenaRegistrationStartWork = false;
+                winConditions.GladiatorArenaRegistrationStartFight = true;
+                winConditions.GladiatorArenaDaysDelayStart = Math.Clamp(settings.GladiatorArenaDaysDelayStart, 1, 60);
+                winConditions.GladiatorArenaCountDay = Math.Clamp(settings.GladiatorArenaCountDay, 1, 30);
+                winConditions.ChampionSelectRule = "StartHero";
             }
-        };
+
+            if (useTournament)
+            {
+                int roundCount = Math.Clamp(settings.TournamentRoundCount, 1, 5);
+                int roundDuration = Math.Clamp(settings.TournamentRoundDuration, 1, 14);
+                int firstAnnounceDay = Math.Clamp(settings.TournamentFirstAnnounceDay, 1, 60);
+                int interval = Math.Clamp(settings.TournamentRoundInterval, 1, 30);
+
+                winConditions.GladiatorArena = false;
+                winConditions.GladiatorArenaRegistrationStartWork = false;
+                winConditions.GladiatorArenaRegistrationStartFight = true;
+                winConditions.GladiatorArenaDaysDelayStart = Math.Clamp(settings.GladiatorArenaDaysDelayStart, 1, 60);
+                winConditions.GladiatorArenaCountDay = Math.Clamp(settings.GladiatorArenaCountDay, 1, 30);
+                winConditions.ChampionSelectRule = "StartHero";
+                winConditions.Tournament = true;
+                winConditions.TournamentDays = Enumerable.Repeat(roundDuration, roundCount).ToList();
+                winConditions.TournamentAnnounceDays = Enumerable.Range(0, roundCount)
+                    .Select(i => firstAnnounceDay + i * interval)
+                    .ToList();
+                winConditions.TournamentPointsToWin = Math.Clamp(settings.TournamentPointsToWin, 1, roundCount);
+                winConditions.TournamentSaveArmy = true;
+            }
+
+            return winConditions;
+        }
 
         private readonly record struct GenerationTuning(
             double ContentScale,
             double ResourceDensityMultiplier,
             double StructureDensityMultiplier,
             double NeutralStackStrengthMultiplier,
-            double BorderGuardStrengthMultiplier);
+            double BorderGuardStrengthMultiplier,
+            double GuardRandomization);
 
         private static int ScaleValue(double value, double multiplier) =>
             Math.Max(0, (int)(value * multiplier));
@@ -183,6 +259,18 @@ namespace Olden_Era___Template_Editor.Services
         private static double ScaleGuardMultiplier(double value, GenerationTuning tuning) =>
             Math.Round(value * tuning.NeutralStackStrengthMultiplier, 3, MidpointRounding.AwayFromZero);
 
+        private static double EffectiveGuardRandomization(GeneratorSettings settings)
+        {
+            if (!settings.AdvancedMode)
+                return DefaultGuardRandomization;
+
+            double value = settings.GuardRandomization;
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                return DefaultGuardRandomization;
+
+            return Math.Round(Math.Clamp(value, 0.0, 0.5), 3, MidpointRounding.AwayFromZero);
+        }
+
         // ── Content scale ────────────────────────────────────────────────────────
 
         /// <summary>
@@ -195,6 +283,14 @@ namespace Olden_Era___Template_Editor.Services
             const double referenceArea = 160.0 * 160.0 / 4.0; // 6400
             double zoneArea = (double)mapSize * mapSize / Math.Max(1, totalZones);
             return Math.Clamp(Math.Sqrt(zoneArea / referenceArea), 0.5, 2.5);
+        }
+
+        private static double NormalizeZoneSize(double zoneSize)
+        {
+            if (double.IsNaN(zoneSize) || double.IsInfinity(zoneSize))
+                return 1.0;
+
+            return Math.Round(Math.Clamp(zoneSize, 0.1, 2.0), 2, MidpointRounding.AwayFromZero);
         }
 
         public static bool CanHonorNeutralSeparation(GeneratorSettings settings, int neutralZoneCount)
@@ -292,9 +388,9 @@ namespace Olden_Era___Template_Editor.Services
 
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.PlayerZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(neutralByLetter[letter], myConns, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildNeutralZone(neutralByLetter[letter], myConns, settings.NeutralZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             var connections = new List<Connection>();
@@ -367,9 +463,9 @@ namespace Olden_Era___Template_Editor.Services
                 var myConns = connsByZone[i].ToArray();
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns, settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.PlayerZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(neutralByLetter[letter], myConns, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildNeutralZone(neutralByLetter[letter], myConns, settings.NeutralZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             if (settings.RandomPortals)
@@ -482,9 +578,9 @@ namespace Olden_Era___Template_Editor.Services
                 var spokeConns = new[] { $"Hub-{letter}" };
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", spokeConns, settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", spokeConns, settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.PlayerZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(neutralByLetter[letter], spokeConns, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildNeutralZone(neutralByLetter[letter], spokeConns, settings.NeutralZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             // Hub → each outer zone: Direct guarded connections (multiple per zone like JCC).
@@ -564,9 +660,9 @@ namespace Olden_Era___Template_Editor.Services
 
                 int playerIdx = playerLetters.IndexOf(letter);
                 if (playerIdx >= 0)
-                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns.ToArray(), settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildSpawnZone(letter, $"Player{playerIdx + 1}", myConns.ToArray(), settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.PlayerZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
                 else
-                    zones.Add(BuildNeutralZone(neutralByLetter[letter], myConns.ToArray(), settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                    zones.Add(BuildNeutralZone(neutralByLetter[letter], myConns.ToArray(), settings.NeutralZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             var connections = new List<Connection>();
@@ -631,7 +727,7 @@ namespace Olden_Era___Template_Editor.Services
                 string[] nConns = n > 1
                     ? new[] { neutralRingConns[prev], neutralRingConns[i] }.Distinct().ToArray()
                     : [];
-                zones.Add(BuildNeutralZone(neutralByLetter[neutrals[i]], nConns, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                zones.Add(BuildNeutralZone(neutralByLetter[neutrals[i]], nConns, settings.NeutralZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
             }
 
             // Build player zones — each connects to two neutrals (evenly distributed).
@@ -645,7 +741,7 @@ namespace Olden_Era___Template_Editor.Services
                 if (n1 != n2)
                     spokeConns.Add($"Web-{playerLetters[i]}-{neutrals[n2]}");
 
-                zones.Add(BuildSpawnZone(playerLetters[i], $"Player{i + 1}", spokeConns.ToArray(), settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
+                zones.Add(BuildSpawnZone(playerLetters[i], $"Player{i + 1}", spokeConns.ToArray(), settings.PlayerZoneCastles, settings.MatchPlayerCastleFactions, settings.PlayerZoneSize, settings.SpawnRemoteFootholds, settings.GenerateRoads, tuning));
 
                 // Player → neutral Direct connections.
                 foreach (var connName in spokeConns)
@@ -709,7 +805,7 @@ namespace Olden_Era___Template_Editor.Services
         {
             Name = "Hub",
             Size = 1.0,
-            Layout = "zone_layout_spawns",
+            Layout = CenterLayoutName,
             GuardCutoffValue = 2000,
             GuardRandomization = 0.05,
             GuardMultiplier = ScaleGuardMultiplier(1.5, tuning),
@@ -839,7 +935,7 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Spawn zone ───────────────────────────────────────────────────────────
 
-        private static Zone BuildSpawnZone(string letter, string player, string[] ringConns, int castleCount, bool matchCastleFactions, bool spawnFootholds, bool generateRoads, GenerationTuning tuning)
+        private static Zone BuildSpawnZone(string letter, string player, string[] ringConns, int castleCount, bool matchCastleFactions, double zoneSize, bool spawnFootholds, bool generateRoads, GenerationTuning tuning)
         {
             // Index 0 = Spawn (player town), indices 1..castleCount-1 = extra cities.
             var mainObjects = new List<MainObject>
@@ -878,10 +974,10 @@ namespace Olden_Era___Template_Editor.Services
             return new Zone
             {
                 Name = $"Spawn-{letter}",
-                Size = 1.0,
-                Layout = "zone_layout_spawns",
+                Size = NormalizeZoneSize(zoneSize),
+                Layout = SpawnLayoutName,
                 GuardCutoffValue = 2000,
-                GuardRandomization = 0.05,
+                GuardRandomization = tuning.GuardRandomization,
                 GuardMultiplier = ScaleGuardMultiplier(1.0, tuning),
                 GuardWeeklyIncrement = 0.20,
                 GuardReactionDistribution = [60, 20, 10, 10, 2, 0],
@@ -908,7 +1004,7 @@ namespace Olden_Era___Template_Editor.Services
 
         // ── Neutral zone ─────────────────────────────────────────────────────────
 
-        private static Zone BuildNeutralZone(NeutralZonePlan plan, string[] ringConns, bool spawnFootholds, bool generateRoads, GenerationTuning tuning)
+        private static Zone BuildNeutralZone(NeutralZonePlan plan, string[] ringConns, double zoneSize, bool spawnFootholds, bool generateRoads, GenerationTuning tuning)
         {
             string letter = plan.Letter;
             int castleCount = plan.CastleCount;
@@ -946,10 +1042,10 @@ namespace Olden_Era___Template_Editor.Services
             return new Zone
             {
                 Name = $"Neutral-{letter}",
-                Size = 1.0,
-                Layout = "zone_layout_spawns",
+                Size = NormalizeZoneSize(zoneSize),
+                Layout = profile.Layout,
                 GuardCutoffValue = 2000,
-                GuardRandomization = 0.05,
+                GuardRandomization = tuning.GuardRandomization,
                 GuardMultiplier = ScaleGuardMultiplier(profile.GuardMultiplier, tuning),
                 GuardWeeklyIncrement = 0.20,
                 GuardReactionDistribution = plan.Quality == NeutralZoneQuality.High ? [0, 10, 10, 20, 10, 0] : [0, 10, 10, 10, 10, 0],
@@ -983,6 +1079,7 @@ namespace Olden_Era___Template_Editor.Services
         private static NeutralZoneProfile GetNeutralZoneProfile(NeutralZoneQuality quality) => quality switch
         {
             NeutralZoneQuality.Low => new NeutralZoneProfile(
+                SideLayoutName,
                 1.0,
                 "template_pool_jebus_cross_guarded_start_zone",
                 "template_pool_jebus_cross_unguarded_start_zone",
@@ -998,6 +1095,7 @@ namespace Olden_Era___Template_Editor.Services
                 "poor_buildings_construction",
                 "poor_buildings_construction"),
             NeutralZoneQuality.High => new NeutralZoneProfile(
+                CenterLayoutName,
                 1.6,
                 "template_pool_jebus_cross_guarded_center_zone",
                 "template_pool_jebus_cross_unguarded_center_zone",
@@ -1013,6 +1111,7 @@ namespace Olden_Era___Template_Editor.Services
                 "rich_buildings_construction",
                 "rich_buildings_construction"),
             _ => new NeutralZoneProfile(
+                TreasureLayoutName,
                 1.3,
                 "template_pool_jebus_cross_guarded_side_zone",
                 "template_pool_jebus_cross_unguarded_side_zone",
@@ -1213,20 +1312,36 @@ namespace Olden_Era___Template_Editor.Services
 
         private static List<ZoneLayout> BuildZoneLayouts() =>
         [
-            new ZoneLayout
+            BuildZoneLayout(SpawnLayoutName, 0.24, 0.48, 0.30, 16, 0.16, 160, -0.30, 0.4, [20, 2, 1]),
+            BuildZoneLayout(SideLayoutName, 0.36, 0.50, 0.25, 16, 0.128, 128, -0.30, 0.3, [20, 2, 1]),
+            BuildZoneLayout(TreasureLayoutName, 0.50, 0.50, 0.45, 12, 0.12, 96, -0.30, 0.3, [12, 3, 1]),
+            BuildZoneLayout(CenterLayoutName, 0.56, 0.60, 0.30, 10, 0.128, 96, -0.25, 0.3, [12, 4, 1])
+        ];
+
+        private static ZoneLayout BuildZoneLayout(
+            string name,
+            double obstaclesFill,
+            double obstaclesFillVoid,
+            double lakesFill,
+            int minLakeArea,
+            double elevationClusterScale,
+            int roadClusterArea,
+            double roadAttraction,
+            double ambientNoise,
+            int[] groupSizeWeights) => new()
             {
-                Name = "zone_layout_spawns",
-                ObstaclesFill = 0.24,
-                ObstaclesFillVoid = 0.48,
-                LakesFill = 0.3,
-                MinLakeArea = 16,
-                ElevationClusterScale = 0.16,
+                Name = name,
+                ObstaclesFill = obstaclesFill,
+                ObstaclesFillVoid = obstaclesFillVoid,
+                LakesFill = lakesFill,
+                MinLakeArea = minLakeArea,
+                ElevationClusterScale = elevationClusterScale,
                 ElevationModes =
                 [
                     new ElevationMode { Weight = 2, MinElevatedFraction = 0.2, MaxElevatedFraction = 0.4 },
                     new ElevationMode { Weight = 1, MinElevatedFraction = 0.6, MaxElevatedFraction = 0.8 }
                 ],
-                RoadClusterArea = 160,
+                RoadClusterArea = roadClusterArea,
                 GuardedEncounterResourceFractions = new GuardedEncounterResourceFractions
                 {
                     CountBounds = [],
@@ -1235,13 +1350,12 @@ namespace Olden_Era___Template_Editor.Services
                 AmbientPickupDistribution = new AmbientPickupDistribution
                 {
                     Repulsion = 1.0,
-                    Noise = 0.4,
-                    RoadAttraction = -0.30,
+                    Noise = ambientNoise,
+                    RoadAttraction = roadAttraction,
                     ObstacleAttraction = 0.0,
-                    GroupSizeWeights = [20, 2, 1]
+                    GroupSizeWeights = groupSizeWeights.ToList()
                 }
-            }
-        ];
+            };
 
         // ── Mandatory content ────────────────────────────────────────────────────
 

--- a/Olden Era - Template Editor/Services/TemplatePreviewPngWriter.cs
+++ b/Olden Era - Template Editor/Services/TemplatePreviewPngWriter.cs
@@ -11,6 +11,10 @@ namespace Olden_Era___Template_Editor.Services
     {
         private const int Width = 512;
         private const int Height = 512;
+        private const string SideLayoutName = "zone_layout_sides";
+        private const string TreasureLayoutName = "zone_layout_treasure_zone";
+        private const string CenterLayoutName = "zone_layout_center";
+        private static readonly Color BackgroundColor = Color.FromRgb(28, 22, 16);
 
         public static string GetSidecarPath(string rmgJsonPath) =>
             rmgJsonPath.EndsWith(".rmg.json", StringComparison.OrdinalIgnoreCase)
@@ -44,7 +48,7 @@ namespace Olden_Era___Template_Editor.Services
 
         private static void DrawPreview(DrawingContext dc, RmgTemplate template)
         {
-            var background = new SolidColorBrush(Color.FromRgb(28, 22, 16));
+            var background = new SolidColorBrush(BackgroundColor);
             var border = new Pen(new SolidColorBrush(Color.FromRgb(143, 115, 63)), 3);
             dc.DrawRectangle(background, null, new Rect(0, 0, Width, Height));
             dc.DrawRoundedRectangle(null, border, new Rect(8, 8, Width - 16, Height - 16), 8, 8);
@@ -123,19 +127,63 @@ namespace Olden_Era___Template_Editor.Services
         {
             bool isSpawn = zone.Name.StartsWith("Spawn-", StringComparison.Ordinal);
             bool isHub = string.Equals(zone.Name, "Hub", StringComparison.Ordinal);
-            bool hasCity = zone.MainObjects?.Any(mainObject => mainObject.Type == "City") == true;
+            bool isNeutral = zone.Name.StartsWith("Neutral-", StringComparison.Ordinal);
+            int castleCount = CastleCount(zone);
 
-            Brush fill = isHub
-                ? new SolidColorBrush(Color.FromRgb(83, 113, 125))
-                : isSpawn
-                    ? new SolidColorBrush(Color.FromRgb(184, 142, 58))
-                    : hasCity
-                        ? new SolidColorBrush(Color.FromRgb(112, 143, 84))
+            Brush fill;
+            Pen outline;
+            if (isNeutral)
+            {
+                (fill, outline) = NeutralZoneStyle(zone);
+            }
+            else
+            {
+                fill = isHub
+                    ? new SolidColorBrush(Color.FromRgb(83, 113, 125))
+                    : isSpawn
+                        ? new SolidColorBrush(Color.FromRgb(184, 142, 58))
                         : new SolidColorBrush(Color.FromRgb(86, 101, 76));
+                outline = new Pen(new SolidColorBrush(Color.FromRgb(245, 225, 179)), 2);
+            }
 
-            var outline = new Pen(new SolidColorBrush(Color.FromRgb(245, 225, 179)), 2);
             dc.DrawEllipse(fill, outline, point, 24, 24);
-            DrawText(dc, ShortZoneLabel(zone.Name), point, 13, Brushes.White, centered: true);
+
+            string label = castleCount > 0 ? castleCount.ToString(CultureInfo.InvariantCulture) : ShortZoneLabel(zone.Name);
+            double labelSize = castleCount > 0 ? 18 : 13;
+            FontWeight labelWeight = castleCount > 0 ? FontWeights.Bold : FontWeights.Normal;
+            DrawText(dc, label, point, labelSize, Brushes.White, centered: true, labelWeight);
+        }
+
+        private static (Brush Fill, Pen Outline) NeutralZoneStyle(Zone zone)
+        {
+            Brush outlineBrush = new SolidColorBrush(Color.FromRgb(245, 225, 179));
+            return zone.Layout switch
+            {
+                SideLayoutName => (
+                    new SolidColorBrush(BackgroundColor),
+                    new Pen(outlineBrush, 3)),
+                CenterLayoutName => (
+                    new SolidColorBrush(Color.FromRgb(214, 166, 61)),
+                    new Pen(new SolidColorBrush(Color.FromRgb(255, 232, 156)), 2)),
+                TreasureLayoutName => (
+                    new SolidColorBrush(Color.FromRgb(173, 176, 176)),
+                    new Pen(new SolidColorBrush(Color.FromRgb(236, 238, 235)), 2)),
+                _ => (
+                    new SolidColorBrush(Color.FromRgb(112, 143, 84)),
+                    new Pen(outlineBrush, 2))
+            };
+        }
+
+        private static int CastleCount(Zone zone)
+        {
+            int count = 0;
+            foreach (MainObject mainObject in zone.MainObjects ?? [])
+            {
+                if (mainObject.Type is "City" or "Spawn")
+                    count++;
+            }
+
+            return count;
         }
 
         private static string ShortZoneLabel(string zoneName)
@@ -145,13 +193,13 @@ namespace Olden_Era___Template_Editor.Services
             return dash >= 0 && dash < zoneName.Length - 1 ? zoneName[(dash + 1)..] : zoneName;
         }
 
-        private static void DrawText(DrawingContext dc, string text, Point point, double size, Brush brush, bool centered)
+        private static void DrawText(DrawingContext dc, string text, Point point, double size, Brush brush, bool centered, FontWeight? weight = null)
         {
             var formatted = new FormattedText(
                 text,
                 CultureInfo.InvariantCulture,
                 FlowDirection.LeftToRight,
-                new Typeface("Segoe UI"),
+                new Typeface(new FontFamily("Segoe UI"), FontStyles.Normal, weight ?? FontWeights.Normal, FontStretches.Normal),
                 size,
                 brush,
                 1.0);

--- a/Olden Era - Template Editor/Services/TemplatePreviewPngWriter.cs
+++ b/Olden Era - Template Editor/Services/TemplatePreviewPngWriter.cs
@@ -1,0 +1,165 @@
+using OldenEraTemplateEditor.Models;
+using System.Globalization;
+using System.IO;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace Olden_Era___Template_Editor.Services
+{
+    public static class TemplatePreviewPngWriter
+    {
+        private const int Width = 512;
+        private const int Height = 512;
+
+        public static string GetSidecarPath(string rmgJsonPath) =>
+            rmgJsonPath.EndsWith(".rmg.json", StringComparison.OrdinalIgnoreCase)
+                ? rmgJsonPath[..^".rmg.json".Length] + ".png"
+                : Path.ChangeExtension(rmgJsonPath, ".png");
+
+        public static void Save(RmgTemplate template, string previewPath)
+        {
+            string? directory = Path.GetDirectoryName(previewPath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            var visual = new DrawingVisual();
+            using (DrawingContext dc = visual.RenderOpen())
+            {
+                DrawPreview(dc, template);
+            }
+
+            var bitmap = new RenderTargetBitmap(Width, Height, 96, 96, PixelFormats.Pbgra32);
+            bitmap.Render(visual);
+
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(bitmap));
+
+            string tempPath = $"{previewPath}.{Guid.NewGuid():N}.tmp";
+            using (var stream = File.Create(tempPath))
+                encoder.Save(stream);
+
+            File.Move(tempPath, previewPath, overwrite: true);
+        }
+
+        private static void DrawPreview(DrawingContext dc, RmgTemplate template)
+        {
+            var background = new SolidColorBrush(Color.FromRgb(28, 22, 16));
+            var border = new Pen(new SolidColorBrush(Color.FromRgb(143, 115, 63)), 3);
+            dc.DrawRectangle(background, null, new Rect(0, 0, Width, Height));
+            dc.DrawRoundedRectangle(null, border, new Rect(8, 8, Width - 16, Height - 16), 8, 8);
+
+            Variant? variant = template.Variants?.FirstOrDefault();
+            List<Zone> zones = variant?.Zones ?? [];
+            if (zones.Count == 0)
+            {
+                DrawText(dc, template.Name, new Point(Width / 2.0, Height / 2.0), 24, Brushes.White, centered: true);
+                return;
+            }
+
+            var orderedZones = OrderZones(zones, variant?.Orientation?.ZeroAngleZone);
+            var positions = LayoutZones(orderedZones);
+            DrawConnections(dc, variant?.Connections ?? [], positions);
+
+            foreach (Zone zone in orderedZones)
+                DrawZone(dc, zone, positions[zone.Name]);
+
+            DrawText(dc, template.Name, new Point(Width / 2.0, 30), 18, new SolidColorBrush(Color.FromRgb(239, 220, 178)), centered: true);
+        }
+
+        private static List<Zone> OrderZones(List<Zone> zones, string? zeroAngleZone)
+        {
+            var ordered = zones.ToList();
+            int zeroIndex = !string.IsNullOrWhiteSpace(zeroAngleZone)
+                ? ordered.FindIndex(zone => string.Equals(zone.Name, zeroAngleZone, StringComparison.Ordinal))
+                : -1;
+
+            if (zeroIndex <= 0) return ordered;
+            return ordered.Skip(zeroIndex).Concat(ordered.Take(zeroIndex)).ToList();
+        }
+
+        private static Dictionary<string, Point> LayoutZones(List<Zone> zones)
+        {
+            var positions = new Dictionary<string, Point>(StringComparer.Ordinal);
+            Zone? hub = zones.FirstOrDefault(zone => string.Equals(zone.Name, "Hub", StringComparison.Ordinal));
+            var outerZones = hub is null ? zones : zones.Where(zone => zone != hub).ToList();
+
+            if (hub is not null)
+                positions[hub.Name] = new Point(Width / 2.0, Height / 2.0);
+
+            double radius = outerZones.Count <= 6 ? 180 : 205;
+            var center = new Point(Width / 2.0, Height / 2.0 + 12);
+
+            for (int i = 0; i < outerZones.Count; i++)
+            {
+                double angle = -Math.PI / 2 + i * Math.PI * 2 / Math.Max(1, outerZones.Count);
+                positions[outerZones[i].Name] = new Point(
+                    center.X + Math.Cos(angle) * radius,
+                    center.Y + Math.Sin(angle) * radius);
+            }
+
+            return positions;
+        }
+
+        private static void DrawConnections(DrawingContext dc, List<Connection> connections, Dictionary<string, Point> positions)
+        {
+            foreach (Connection connection in connections)
+            {
+                if (!positions.TryGetValue(connection.From, out Point from)) continue;
+                if (!positions.TryGetValue(connection.To, out Point to)) continue;
+
+                var brush = connection.ConnectionType == "Portal"
+                    ? new SolidColorBrush(Color.FromRgb(125, 186, 196))
+                    : new SolidColorBrush(Color.FromRgb(122, 97, 55));
+                var pen = new Pen(brush, connection.ConnectionType == "Proximity" ? 1 : 2);
+                if (connection.ConnectionType == "Portal")
+                    pen.DashStyle = DashStyles.Dash;
+
+                dc.DrawLine(pen, from, to);
+            }
+        }
+
+        private static void DrawZone(DrawingContext dc, Zone zone, Point point)
+        {
+            bool isSpawn = zone.Name.StartsWith("Spawn-", StringComparison.Ordinal);
+            bool isHub = string.Equals(zone.Name, "Hub", StringComparison.Ordinal);
+            bool hasCity = zone.MainObjects?.Any(mainObject => mainObject.Type == "City") == true;
+
+            Brush fill = isHub
+                ? new SolidColorBrush(Color.FromRgb(83, 113, 125))
+                : isSpawn
+                    ? new SolidColorBrush(Color.FromRgb(184, 142, 58))
+                    : hasCity
+                        ? new SolidColorBrush(Color.FromRgb(112, 143, 84))
+                        : new SolidColorBrush(Color.FromRgb(86, 101, 76));
+
+            var outline = new Pen(new SolidColorBrush(Color.FromRgb(245, 225, 179)), 2);
+            dc.DrawEllipse(fill, outline, point, 24, 24);
+            DrawText(dc, ShortZoneLabel(zone.Name), point, 13, Brushes.White, centered: true);
+        }
+
+        private static string ShortZoneLabel(string zoneName)
+        {
+            if (string.Equals(zoneName, "Hub", StringComparison.Ordinal)) return "Hub";
+            int dash = zoneName.LastIndexOf('-');
+            return dash >= 0 && dash < zoneName.Length - 1 ? zoneName[(dash + 1)..] : zoneName;
+        }
+
+        private static void DrawText(DrawingContext dc, string text, Point point, double size, Brush brush, bool centered)
+        {
+            var formatted = new FormattedText(
+                text,
+                CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface("Segoe UI"),
+                size,
+                brush,
+                1.0);
+
+            var origin = centered
+                ? new Point(point.X - formatted.Width / 2, point.Y - formatted.Height / 2)
+                : point;
+            dc.DrawText(formatted, origin);
+        }
+    }
+}


### PR DESCRIPTION
Please re-check this after the previous PR merges as they are on a stack of changes

<img width="1920" height="1200" alt="Screenshot 2026-05-02 210839" src="https://github.com/user-attachments/assets/91091e31-cce0-434a-b679-dec206fe776f" />
<img width="1920" height="1200" alt="Screenshot 2026-05-02 211106" src="https://github.com/user-attachments/assets/ccc4882b-2caa-4a61-875a-998ddafcc5b5" />
