### PR TITLE
Fix starting window height

### DIFF
--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Olden Era - Simple Template Generator"
-        Height="950" Width="1050"
+        Height="800" Width="1050"
         MinHeight="800" MinWidth="1050"
         WindowStyle="None"
         ResizeMode="CanResize"


### PR DESCRIPTION
On Win11, 1920x1080 resolution and on the recommended Scale (125%), the toolbar is hidden (New, Open, Save, Save as) and the  draggable area/title bar is just outside of reach. Making it unable to drag it down, minimize, put it to fullscreen or exit the app.

This PR reduces the starting height. 950 => 800

<img width="1319" height="1019" alt="image" src="https://github.com/user-attachments/assets/3c075ff1-6c30-4e47-8488-7cfdf88fdb4d" />
