### PR TITLE
Limit the Tournament Announcement Day slider

### DIFF
--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Olden_Era___Template_Editor"
         mc:Ignorable="d"
         Title="Olden Era - Simple Template Generator"
         Height="800" Width="1050"
@@ -39,6 +40,7 @@
         <Style x:Key="RowSpacer" TargetType="RowDefinition">
             <Setter Property="Height" Value="8"/>
         </Style>
+        <local:MaxAnnouncementDaysConverter x:Key="MaxAnnouncementDaysConverter"/>
     </Window.Resources>
 
     <!-- Outer border gives the window its themed frame -->
@@ -412,7 +414,7 @@
                                                    Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
                                     </DockPanel>
                                     <Slider Grid.Row="2" Grid.Column="1" x:Name="SldTournamentFirstTournamentDay"
-                                            Minimum="1" Maximum="30" Value="8"
+                                            Minimum="2" Maximum="30" Value="8"
                                             TickFrequency="1" IsSnapToTickEnabled="True"
                                             ValueChanged="Slider_ValueChanged"/>
                                     <DockPanel Grid.Row="4" Grid.Column="0">
@@ -422,9 +424,16 @@
                                                    Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
                                     </DockPanel>
                                     <Slider Grid.Row="4" Grid.Column="1" x:Name="SldTournamentAnnouncementLeadDays"
-                                            Minimum="1" Maximum="10" Value="3"
+                                            Minimum="1" Value="3"
                                             TickFrequency="1" IsSnapToTickEnabled="True"
-                                            ValueChanged="Slider_ValueChanged"/>
+                                            ValueChanged="Slider_ValueChanged">
+                                        <Slider.Maximum>
+                                            <MultiBinding Converter="{StaticResource MaxAnnouncementDaysConverter}">
+                                                <Binding ElementName="SldTournamentFirstTournamentDay" Path="Value"/>
+                                                <Binding ElementName="SldTournamentInterval" Path="Value"/>
+                                            </MultiBinding>
+                                        </Slider.Maximum>
+                                    </Slider>
                                     <DockPanel Grid.Row="6" Grid.Column="0">
                                         <Label Content="Days between rounds" Padding="5,2" DockPanel.Dock="Left"/>
                                         <TextBlock x:Name="TxtTournamentInterval" Text="7" DockPanel.Dock="Right"
@@ -432,7 +441,7 @@
                                                    Margin="0,0,4,0" Style="{StaticResource ValueText}"/>
                                     </DockPanel>
                                     <Slider Grid.Row="6" Grid.Column="1" x:Name="SldTournamentInterval"
-                                            Minimum="1" Maximum="30" Value="7"
+                                            Minimum="2" Maximum="30" Value="7"
                                             TickFrequency="1" IsSnapToTickEnabled="True"
                                             ValueChanged="Slider_ValueChanged"/>
                                                 </Grid>

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -523,7 +523,7 @@ namespace Olden_Era___Template_Editor
             SldGladiatorCountDay.Value = 3;
 
             SldTournamentPointsToWin.Value = 2;
-            SldTournamentInterval.Value = 3;
+            SldTournamentInterval.Value = 7;
             SldTournamentFirstTournamentDay.Value = 8;
             SldTournamentAnnouncementLeadDays.Value = 3;
 
@@ -746,9 +746,9 @@ namespace Olden_Era___Template_Editor
             SldGladiatorDelay.Value = Math.Clamp(s.GladiatorArenaDaysDelayStart, 1, 60);
             SldGladiatorCountDay.Value = Math.Clamp(s.GladiatorArenaCountDay, 1, 30);
             ChkTournament.IsChecked = s.Tournament;
-            SldTournamentFirstTournamentDay.Value = Math.Clamp(s.TournamentFirstTournamentDay, 1, 14);
+            SldTournamentFirstTournamentDay.Value = Math.Clamp(s.TournamentFirstTournamentDay, 2, 14);
             SldTournamentAnnouncementLeadDays.Value = Math.Clamp(s.TournamentAnnouncementLeadDays, 1, 60);
-            SldTournamentInterval.Value = Math.Clamp(s.TournamentInterval, 1, 30);
+            SldTournamentInterval.Value = Math.Clamp(s.TournamentInterval, 2, 30);
             SldTournamentPointsToWin.Value = Math.Clamp(s.TournamentPointsToWin, 1, 5);
             UpdateValueLabels();
             UpdateAdvancedZoneSettingsVisibility();

--- a/Olden Era - Template Editor/MaxAnnouncementDaysConverter.cs
+++ b/Olden Era - Template Editor/MaxAnnouncementDaysConverter.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Olden_Era___Template_Editor
+{
+    // Tournament Announcement Days must be less than First Tournament Day and Tournament Interval!
+    public class MaxAnnouncementDaysConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values == null || values.Length != 2)
+                return 1.0;
+
+            if (!TryToDouble(values[0], out double a) || !TryToDouble(values[1], out double b))
+                return 1.0;
+
+            double days = Math.Min(a, b) - 1.0;
+            if (double.IsNaN(days) || days < 1.0)
+                days = 1.0;
+
+            return days;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+        private static bool TryToDouble(object? value, out double result)
+        {
+            result = 0;
+            if (value == null) return false;
+            if (value is double d) { result = d; return true; }
+            if (value is float f) { result = f; return true; }
+            if (value is int i) { result = i; return true; }
+            if (double.TryParse(value.ToString(), out d)) { result = d; return true; }
+            return false;
+        }
+    }
+}

--- a/Olden Era - Template Editor/Services/TemplateGenerator.cs
+++ b/Olden Era - Template Editor/Services/TemplateGenerator.cs
@@ -408,9 +408,9 @@ namespace Olden_Era___Template_Editor.Services
 
             if (useTournament)
             {
-                int firstTournamentDay = Math.Clamp(settings.TournamentFirstTournamentDay, 1, 60);
+                int firstTournamentDay = Math.Clamp(settings.TournamentFirstTournamentDay, 2, 60);
                 int announcementLeadDays = Math.Clamp(settings.TournamentAnnouncementLeadDays, 1, 30);
-                int tournamentInterval = Math.Clamp(settings.TournamentInterval, 1, 30);
+                int tournamentInterval = Math.Clamp(settings.TournamentInterval, 2, 30);
                 int pointsToWin = Math.Clamp(settings.TournamentPointsToWin, 1, 5);
                 // Round count is derived from points to win: with N points to win, the maximum number of rounds is 2N-1
                 int roundCount = pointsToWin * 2 - 1;


### PR DESCRIPTION
I like the tournament mode and noticed the following bug:
If announcement days <= first day of tournament: no fight ever happens.
If announcement days <= tournament interval: no subsequent fights will happen.

Thus, I set the minimum for first day and interval to 2 instead of 1,
and set the maximum for the announcement days slider to min(first day, interval) - 1
This is included in the PR.

I would even propose to get rid of the announcement days variable altogether, because I don't see its value.
Players probably want to know when the next fight wil happen as soon as possible.