### PR TITLE
Added Content Item manager for abstracting template hardcoded values.

### DIFF
--- a/Olden Era - Template Editor/Services/ContentManagement/ContentIds.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ContentIds.cs
@@ -1,0 +1,78 @@
+namespace OldenEraTemplateEditor.Services.ContentManagement
+{
+/* Centralized content IDs for easy reference throughout the application. Generated from KnownValues.cs ObjectSids */
+public static class ContentIds
+{
+    public const string AlchemyLab = "alchemy_lab";
+    public const string Arena = "arena";
+    public const string BeerFountain = "beer_fountain";
+    public const string BorealCall = "boreal_call";
+    public const string CelestialSphere = "celestial_sphere";
+    public const string Chimerologist = "chimerologist";
+    public const string Circus = "circus";
+    public const string CollegeOfWonder = "college_of_wonder";
+    public const string CrystalTrail = "crystal_trail";
+    public const string DragonUtopia = "dragon_utopia";
+    public const string EternalDragon = "eternal_dragon";
+    public const string FickleShrine = "fickle_shrine";
+    public const string FlatteringMirror = "flattering_mirror";
+    public const string Forge = "forge";
+    public const string Fort = "fort";
+    public const string Fountain = "fountain";
+    public const string Fountain2 = "fountain_2";
+    public const string HuntsmansCamp = "huntsmans_camp";
+    public const string InfernalCirque = "infernal_cirque";
+    public const string InsarasEye = "insaras_eye";
+    public const string JoustingRange = "jousting_range";
+    public const string ManaWell = "mana_well";
+    public const string Market = "market";
+    public const string MineCrystals = "mine_crystals";
+    public const string MineGemstones = "mine_gemstones";
+    public const string MineGold = "mine_gold";
+    public const string MineMercury = "mine_mercury";
+    public const string MineOre = "mine_ore";
+    public const string MineWood = "mine_wood";
+    public const string Mirage = "mirage";
+    public const string MontyHall = "monty_hall";
+    public const string MysteriousStone = "mysterious_stone";
+    public const string MysticalTower = "mystical_tower";
+    public const string MythicScrollBox = "mythic_scroll_box";
+    public const string OrbObservatory = "orb_observatory";
+    public const string PandoraBox = "pandora_box";
+    public const string PetrifiedMemorial = "petrified_memorial";
+    public const string PileOfBooks = "pile_of_books";
+    public const string PointOfBalance = "point_of_balance";
+    public const string Prison = "prison";
+    public const string QuixsPath = "quixs_path";
+    public const string RandomHire1 = "random_hire_1";
+    public const string RandomHire2 = "random_hire_2";
+    public const string RandomHire3 = "random_hire_3";
+    public const string RandomHire4 = "random_hire_4";
+    public const string RandomHire5 = "random_hire_5";
+    public const string RandomHire6 = "random_hire_6";
+    public const string RandomHire7 = "random_hire_7";
+    public const string RandomItemCommon = "random_item_common";
+    public const string RandomItemEpic = "random_item_epic";
+    public const string RandomItemLegendary = "random_item_legendary";
+    public const string RandomItemRare = "random_item_rare";
+    public const string RemoteFoothold = "remote_foothold";
+    public const string ResearchLaboratory = "research_laboratory";
+    public const string RitualPyre = "ritual_pyre";
+    public const string SacrificialShrine = "sacrificial_shrine";
+    public const string ShadyDen = "shady_den";
+    public const string Stables = "stables";
+    public const string Tavern = "tavern";
+    public const string TearOfTruth = "tear_of_truth";
+    public const string TheGorge = "the_gorge";
+    public const string TownGate = "town_gate";
+    public const string TreeOfAbundance = "tree_of_abundance";
+    public const string TroglodyteThrone = "troglodyte_throne";
+    public const string UnforgottenGrave = "unforgotten_grave";
+    public const string University = "university";
+    public const string UnstableRuins = "unstable_ruins";
+    public const string Watchtower = "watchtower";
+    public const string WindRose = "wind_rose";
+    public const string WiseOwl = "wise_owl";
+}
+
+}

--- a/Olden Era - Template Editor/Services/ContentManagement/ContentItemBuilder.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ContentItemBuilder.cs
@@ -1,0 +1,77 @@
+using OldenEraTemplateEditor.Models;
+namespace OldenEraTemplateEditor.Services.ContentManagement
+{
+
+/* Generic ContentItem builder for managing the content within zones. */
+public class ContentItemBuilder
+{
+    private readonly ContentItem _item = new();
+
+    public static ContentItemBuilder Create(string sid)
+    {
+        return new ContentItemBuilder().WithSid(sid);
+    }
+
+    public ContentItemBuilder WithSid(string sid)
+    {
+        _item.Sid = sid;
+        return this;
+    }
+
+    public ContentItemBuilder WithName(string name)
+    {
+        _item.Name = name;
+        return this;
+    }
+
+    public ContentItemBuilder WithVariant(int variant)
+    {
+        _item.Variant = variant;
+        return this;
+    }
+
+    public ContentItemBuilder Guarded(bool value = true)
+    {
+        _item.IsGuarded = value;
+        return this;
+    }
+
+    public ContentItemBuilder Mine(bool value = true)
+    {
+        _item.IsMine = value;
+        return this;
+    }
+
+    public ContentItemBuilder SoloEncounter(bool value = true)
+    {
+        _item.SoloEncounter = value;
+        return this;
+    }
+    public ContentItemBuilder AddRule(ContentPlacementRule rule)
+    {
+        _item.Rules ??= new List<ContentPlacementRule>();
+        _item.Rules.Add(rule);
+        return this;
+    }
+    public ContentItemBuilder AddRules(IEnumerable<ContentPlacementRule> rules)
+    {
+        _item.Rules ??= new List<ContentPlacementRule>();
+        _item.Rules.AddRange(rules);
+        return this;
+    }
+
+    public ContentItemBuilder AddIncludeList(string list)
+    {
+        _item.IncludeLists ??= new List<string>();
+        _item.IncludeLists.Add(list);
+        return this;
+    }
+    public ContentItemBuilder AddIncludeLists(IEnumerable<string> lists)
+    {
+        _item.IncludeLists ??= new List<string>();
+        _item.IncludeLists.AddRange(lists);
+        return this;
+    }
+    public ContentItem Build() => _item;
+}
+}

--- a/Olden Era - Template Editor/Services/ContentManagement/ContentItemBuilder.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ContentItemBuilder.cs
@@ -60,6 +60,9 @@ public class ContentItemBuilder
         return this;
     }
 
+    // Helper for common rule for content items regarding distance from roads.
+    public ContentItemBuilder RoadDistance(DistanceVariation distance, int weight = 1) => AddRule(RulePresets.RoadDistance(distance, weight));
+
     public ContentItemBuilder AddIncludeList(string list)
     {
         _item.IncludeLists ??= new List<string>();

--- a/Olden Era - Template Editor/Services/ContentManagement/ContentPresets.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ContentPresets.cs
@@ -40,7 +40,7 @@ public static class ContentPresets
             .Guarded()
             .AddRules([
                 new ContentPlacementRule { Type = "MainObject", Args = ["0"], TargetMin = 0.15, TargetMax = 0.35, Weight = 1 },
-                RulePresets.AtCrossroads(0.15, 0.30)
+                RulePresets.CrossroadsDistance(DistancePresets.Near)
             ])
             .Build();
     /* Basic ore mine, guarded & anchored near the player castle */
@@ -51,50 +51,42 @@ public static class ContentPresets
             .Guarded()
             .AddRules([
                 new ContentPlacementRule { Type = "MainObject", Args = ["0"], TargetMin = 0.15, TargetMax = 0.35, Weight = 1 },
-                RulePresets.AtCrossroads(0.15, 0.30)
+                RulePresets.CrossroadsDistance(DistancePresets.Near)
             ])
             .Build();
     /* Gold mine near crossroads */
-    public static ContentItem MineGold_Crossroads() => 
+    public static ContentItem MineGold_NearCrossroads() => 
         ContentItemBuilder.Create(ContentIds.MineGold)
             .Mine()
             .AddRules([
-                RulePresets.AtCrossroads(0.10, 0.30)
+                RulePresets.CrossroadsDistance(DistancePresets.Near)
             ])
             .Build();
     
     /* Mines near roads */
-    public static ContentItem MineCrystals_Road() =>
+    public static ContentItem MineCrystals_NextToRoad() =>
         ContentItemBuilder.Create(ContentIds.MineCrystals)
             .WithName("name_mine_crystals")
             .Mine()
-            .AddRules([
-                RulePresets.NearRoad(0.05, 0.10)
-            ])
+            .RoadDistance(DistancePresets.NextTo)
             .Build();
-    public static ContentItem MineMercury_Road() =>
+    public static ContentItem MineMercury_NextToRoad() =>
         ContentItemBuilder.Create(ContentIds.MineMercury)
             .WithName("name_mine_mercury")
             .Mine()
-            .AddRules([
-                RulePresets.NearRoad(0.05, 0.10)
-            ])
+            .RoadDistance(DistancePresets.NextTo)
             .Build();
-    public static ContentItem MineGemstones_Road() =>
+    public static ContentItem MineGemstones_NextToRoad() =>
         ContentItemBuilder.Create(ContentIds.MineGemstones)
             .WithName("name_mine_gemstones")
             .Mine()
-            .AddRules([
-                RulePresets.NearRoad(0.05, 0.10)
-            ])
+            .RoadDistance(DistancePresets.NextTo)
             .Build();
-    public static ContentItem AlchemyLab_Road() =>
+    public static ContentItem AlchemyLab_NearRoad() =>
         ContentItemBuilder.Create(ContentIds.AlchemyLab)
             .WithName("name_alchemy_lab")
             .Mine()
-            .AddRules([
-                RulePresets.NearRoad(0.20, 0.30)
-            ])
+            .RoadDistance(DistancePresets.Near)
             .Build();
 
     

--- a/Olden Era - Template Editor/Services/ContentManagement/ContentPresets.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ContentPresets.cs
@@ -1,0 +1,104 @@
+using System.Data;
+using OldenEraTemplateEditor.Models;
+
+namespace OldenEraTemplateEditor.Services.ContentManagement
+{
+public static class ContentPresets
+{
+    /* Foothold rules derived from example templates. Might need adjustment. */
+    private static List<ContentPlacementRule> FootholdRules(int castleCount)
+    {
+        var rules = new List<ContentPlacementRule>
+        {
+            new() { Type = "Crossroads", Args = [], TargetMin = 0.2, TargetMax = 0.3, Weight = 0 },
+        };
+        if (castleCount > 0)
+            // Not sure about what exactly weight == 0 does (doesn't it mean no impact?), but it's present in the original templates.
+            rules.Add(new ContentPlacementRule { Type = "MainObject", Args = ["0"], TargetMin = 0.2, TargetMax = 0.4, Weight = 0 });
+        if (castleCount > 1)
+            rules.Add(new ContentPlacementRule { Type = "MainObject", Args = ["1"], TargetMin = 0.5, TargetMax = 0.5, Weight = 2 });
+        return rules;
+    }
+
+    public static ContentItem RemoteFoothold(int castleCount)
+    { 
+        var rules = FootholdRules(castleCount);
+
+        return ContentItemBuilder.Create(ContentIds.RemoteFoothold)
+            .WithName("name_remote_foothold_1") // Think about uniqueness of names... It's duplicated in some templates, but might be important.
+            .SoloEncounter()
+            .Guarded(false)
+            .AddRules(rules)
+            .Build();
+    }
+    
+    /* Basic wood mine, guarded & anchored near the player castle */
+    public static ContentItem MineWood_Anchored() => 
+        ContentItemBuilder.Create(ContentIds.MineWood)
+            .WithName("name_mine_wood")
+            .Mine()
+            .Guarded()
+            .AddRules([
+                new ContentPlacementRule { Type = "MainObject", Args = ["0"], TargetMin = 0.15, TargetMax = 0.35, Weight = 1 },
+                RulePresets.AtCrossroads(0.15, 0.30)
+            ])
+            .Build();
+    /* Basic ore mine, guarded & anchored near the player castle */
+    public static ContentItem MineOre_Anchored() => 
+        ContentItemBuilder.Create(ContentIds.MineOre)
+            .WithName("name_mine_ore")
+            .Mine()
+            .Guarded()
+            .AddRules([
+                new ContentPlacementRule { Type = "MainObject", Args = ["0"], TargetMin = 0.15, TargetMax = 0.35, Weight = 1 },
+                RulePresets.AtCrossroads(0.15, 0.30)
+            ])
+            .Build();
+    /* Gold mine near crossroads */
+    public static ContentItem MineGold_Crossroads() => 
+        ContentItemBuilder.Create(ContentIds.MineGold)
+            .Mine()
+            .AddRules([
+                RulePresets.AtCrossroads(0.10, 0.30)
+            ])
+            .Build();
+    
+    /* Mines near roads */
+    public static ContentItem MineCrystals_Road() =>
+        ContentItemBuilder.Create(ContentIds.MineCrystals)
+            .WithName("name_mine_crystals")
+            .Mine()
+            .AddRules([
+                RulePresets.NearRoad(0.05, 0.10)
+            ])
+            .Build();
+    public static ContentItem MineMercury_Road() =>
+        ContentItemBuilder.Create(ContentIds.MineMercury)
+            .WithName("name_mine_mercury")
+            .Mine()
+            .AddRules([
+                RulePresets.NearRoad(0.05, 0.10)
+            ])
+            .Build();
+    public static ContentItem MineGemstones_Road() =>
+        ContentItemBuilder.Create(ContentIds.MineGemstones)
+            .WithName("name_mine_gemstones")
+            .Mine()
+            .AddRules([
+                RulePresets.NearRoad(0.05, 0.10)
+            ])
+            .Build();
+    public static ContentItem AlchemyLab_Road() =>
+        ContentItemBuilder.Create(ContentIds.AlchemyLab)
+            .WithName("name_alchemy_lab")
+            .Mine()
+            .AddRules([
+                RulePresets.NearRoad(0.20, 0.30)
+            ])
+            .Build();
+
+    
+
+}
+
+}

--- a/Olden Era - Template Editor/Services/ContentManagement/DistancePresets.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/DistancePresets.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using OldenEraTemplateEditor.Models;
+
+namespace OldenEraTemplateEditor.Services.ContentManagement
+{
+
+public struct DistanceVariation
+{
+    public double Min { get; set; }
+    public double Max { get; set; }
+}
+public static class DistancePresets
+{
+    public static DistanceVariation NextTo = new DistanceVariation { Min = 0.05, Max = 0.1 };
+    public static DistanceVariation Near = new DistanceVariation { Min = 0.1, Max = 0.25 };
+    public static DistanceVariation Medium = new DistanceVariation { Min = 0.25, Max = 0.5 };
+    public static DistanceVariation Far = new DistanceVariation { Min = 0.5, Max = 0.75 };
+    public static DistanceVariation VeryFar = new DistanceVariation { Min = 0.75, Max = 0.9 };
+}
+
+}

--- a/Olden Era - Template Editor/Services/ContentManagement/RulePresets.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/RulePresets.cs
@@ -7,11 +7,11 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
 /* Some commonly found rulesets, to avoid repetition and ensure consistency across templates. */
 public static class RulePresets
 {
-    public static ContentPlacementRule AtCrossroads(double min, double max, int weight = 1)=> 
-        new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = min, TargetMax = max, Weight = weight };
+    public static ContentPlacementRule RoadDistance(DistanceVariation distance, int weight = 1) => 
+        new ContentPlacementRule { Type = "Road", Args = [], TargetMin = distance.Min, TargetMax = distance.Max, Weight = weight };
 
-    public static ContentPlacementRule NearRoad(double min, double max, int weight = 1) => 
-        new ContentPlacementRule { Type = "Road", Args = [], TargetMin = min, TargetMax = max, Weight = weight };
-    
+    public static ContentPlacementRule CrossroadsDistance(DistanceVariation distance, int weight = 1)=> 
+        new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = distance.Min, TargetMax = distance.Max, Weight = weight };
+
 }
 }

--- a/Olden Era - Template Editor/Services/ContentManagement/RulePresets.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/RulePresets.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using OldenEraTemplateEditor.Models;
+
+namespace OldenEraTemplateEditor.Services.ContentManagement
+{
+
+/* Some commonly found rulesets, to avoid repetition and ensure consistency across templates. */
+public static class RulePresets
+{
+    public static ContentPlacementRule AtCrossroads(double min, double max, int weight = 1)=> 
+        new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = min, TargetMax = max, Weight = weight };
+
+    public static ContentPlacementRule NearRoad(double min, double max, int weight = 1) => 
+        new ContentPlacementRule { Type = "Road", Args = [], TargetMin = min, TargetMax = max, Weight = weight };
+    
+}
+}

--- a/Olden Era - Template Editor/Services/ContentManagement/ZoneContentManager.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ZoneContentManager.cs
@@ -1,0 +1,219 @@
+using OldenEraTemplateEditor.Models;
+
+namespace OldenEraTemplateEditor.Services.ContentManagement
+{
+/* Content manager for defining zone-specific content */
+public static class ZoneContentManager
+{
+    /// <summary>
+    /// Player spawn zone — guaranteed starter mines anchored near the castle, a full rare mine
+    /// set spread along roads, utility/economic buildings, tier-split hiring picks, one hero
+    /// stat trainer, guarded resource banks, and starter loot.
+    /// Grounded in the consensus across Exodus, Staircase, Kerberos, Blitz, Universe, and
+    /// Yin Yang spawn zones from the example template corpus.
+    /// </summary>
+    public static List<ContentItem> BuildPlayerZoneMandatoryContent(int castleCount, bool spawnFootholds)
+    {
+        var content = new List<ContentItem>();
+
+        if (spawnFootholds)
+            content.Add(ContentPresets.RemoteFoothold(castleCount));
+
+        content.AddRange([
+            // ── Basic mines — guarded, anchored near the player castle (every template). ──
+            ContentPresets.MineWood_Anchored(),
+            ContentPresets.MineOre_Anchored(),
+            // ── Gold mine near crossroads (Exodus/Staircase/Yin Yang pattern). ──
+            ContentPresets.MineGold_NearCrossroads(),
+            // ── Rare mines spread along roads (Exodus/Staircase/Yin Yang pattern). ──
+            ContentPresets.MineCrystals_NextToRoad(),
+            ContentPresets.MineMercury_NextToRoad(),
+            ContentPresets.MineGemstones_NextToRoad(),
+            ContentPresets.AlchemyLab_NearRoad(),
+            // ── Utility buildings (Blitz/Kerberos/Exodus pattern). ──
+            new() { Sid = "watchtower" },
+            ContentItemBuilder.Create(ContentIds.Market).Guarded().RoadDistance(DistancePresets.Near).Build(),
+            ContentItemBuilder.Create(ContentIds.ManaWell).RoadDistance(DistancePresets.Near).Build(),
+            // ── Hero training — tier-2 stat building (fort/university/orb_observatory) ──
+            //    + uncommon hero bank (university/wise_owl/tree_of_knowledge) (Blitz/Exodus pattern).
+            new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_2"] },
+            new() { IncludeLists = ["content_list_building_uncommon_hero_banks"] },
+
+            // ── Hiring — low-tier × 2 + high-tier × 1 + full pool × 1 (Kerberos + Universe blend). ──
+            new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
+            new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
+            new() { IncludeLists = ["content_list_building_random_hires_high_tier"] },
+            new() { IncludeLists = ["basic_content_list_building_random_hires"] },
+
+            // ── Guarded resource banks — tier 1 × 2 + tier 2 × 1 (Exodus pattern). ──
+            new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_1"] },
+            new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_1"] },
+            new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_2"] },
+
+            // ── Loot — epic items + army pandora (Exodus/Blitz pattern). ──
+            ContentItemBuilder.Create(ContentIds.RandomItemEpic).SoloEncounter().Build(),
+            ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
+            new() { IncludeLists = ["content_list_pickup_pandora_box_army_low_tier"] },
+        ]);
+        return content;
+    }
+
+    /// <summary>
+    /// Low-quality neutral zone — t2 pools, intentionally lean mandatory content.
+    /// The t2 content pools supply most of the variety; mandatory content only guarantees
+    /// the essential items that every low zone must have: a few rare mines, basic utility
+    /// buildings, and a handful of random hires. Modelled after Universe side zones,
+    /// Kerberos connector zones, and Madness side zones from the template corpus.
+    /// No high-end encounters (no dragon utopias, research labs, unstable ruins).
+    /// </summary>
+    public static List<ContentItem> BuildLowNeutralMandatoryContent(int castleCount, bool spawnFootholds)
+    {
+        var content = new List<ContentItem>();
+
+        if (spawnFootholds)
+            content.Add(ContentPresets.RemoteFoothold(castleCount));
+
+        content.AddRange([
+            // Mines — biome-based rare mine + one fixed rare mine (Blitz Side-1 pattern).
+            new() { Name = "name_mine_by_biome_1", IncludeLists = ["basic_content_list_rare_mines_by_biome"], IsMine = true },
+            new() { IncludeLists = ["basic_content_list_rare_mines"], IsMine = true },
+            // Utility — one guarded market near crossroads, one vision building.
+            ContentItemBuilder.Create(ContentIds.Market).Guarded().AddRule(RulePresets.CrossroadsDistance(DistancePresets.Near)).Build(),
+            new() { IncludeLists = ["basic_content_list_vision_buildings_tier_1"] },
+            // Buff buildings — picked from the real hero-buff pool (mana_well, fountain, stables, etc.).
+            new() { IncludeLists = ["basic_content_list_building_hero_buff_tier_1"] },
+            new() { IncludeLists = ["basic_content_list_building_hero_buff_tier_1"] },
+            // Common hero stat building (stinging_sword, armory_automaton, magic_wheel, knowledge_garden).
+            new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_1"] },
+            // Hiring — low-tier random hires (hires 1–4, confirmed content_list name).
+            new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
+            new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
+            // Loot — solo pandora box + low-tier army pandora (variants 8–11).
+            ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
+            new() { IncludeLists = ["content_list_pickup_pandora_box_army_low_tier"] },
+            // Pickup — random item + common magic pickup.
+            new() { IncludeLists = ["basic_content_list_pickup_random_items"] },
+            new() { IncludeLists = ["basic_content_list_building_magic_tier_1"] },
+        ]);
+
+        return content;
+    }
+
+    /// <summary>
+    /// Medium-quality neutral zone — t3 pools, tier-3 resource banks, medium hires, stat buildings,
+    /// epic+legendary loot, pandora boxes, gold and rare mines.
+    /// Based on t3-pool side/treasure zones found in Staircase, Shamrock, Blitz, Kerberos, and similar templates.
+    /// No high-end encounters (no dragon utopias, research labs, unstable ruins).
+    /// </summary>
+    public static List<ContentItem> BuildMediumNeutralMandatoryContent(int castleCount, bool spawnFootholds)
+    {
+        var content = new List<ContentItem>();
+
+        if (spawnFootholds)
+            content.Add(ContentPresets.RemoteFoothold(castleCount));
+
+        content.AddRange([
+            // Mines — full rare set + gold + alchemy lab (Yin Yang/Staircase t3 pattern).
+            ContentPresets.MineCrystals_NextToRoad(),
+            ContentPresets.MineMercury_NextToRoad(),
+            ContentPresets.MineGemstones_NextToRoad(),
+            ContentPresets.AlchemyLab_NearRoad(),
+            ContentItemBuilder.Create(ContentIds.MineGold).Mine().RoadDistance(DistancePresets.Near).Build(),
+            // Utility — watchtower (guarded) + vision building (tier 1 only: flattering_mirror/watchtower).
+            // wind_rose (full map reveal) lives in tier_2 and belongs exclusively in high zones.
+            ContentItemBuilder.Create(ContentIds.Watchtower).Guarded().Build(),
+            new() { IncludeLists = ["basic_content_list_vision_buildings_tier_1"] },
+            // Buff buildings.
+            new() { IncludeLists = ["basic_content_list_building_hero_buff_tier_1"] },
+            // Hero stats — tier 1 common + tier 2 uncommon picks.
+            new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_1"] },
+            new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_2"] },
+            // Magic buildings — tier 1 + tier 2.
+            new() { IncludeLists = ["basic_content_list_building_magic_tier_1"] },
+            new() { IncludeLists = ["basic_content_list_building_magic_tier_2"] },
+            // Hiring — low-tier + high-tier random hires (confirmed generator list names).
+            new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
+            new() { IncludeLists = ["content_list_building_random_hires_high_tier"] },
+            // Unit banks — biome-restricted (Blitz Treasure-2 pattern).
+            new() { IncludeLists = ["basic_content_list_building_guarded_units_banks_only_biome_restriction"] },
+            // Guarded resource banks — tier 2 (no black tower / tier-1 banks).
+            new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_2"] },
+            // Loot — epic items + pandora boxes with army variants.
+            ContentItemBuilder.Create(ContentIds.RandomItemEpic).SoloEncounter().Build(),
+            ContentItemBuilder.Create(ContentIds.RandomItemEpic).Build(),
+            ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
+            ContentItemBuilder.Create(ContentIds.PandoraBox).Build(),
+            new() { IncludeLists = ["content_list_pickup_pandora_box_army_low_tier"] },
+        ]);
+
+        return content;
+    }
+
+    /// <summary>
+    /// High-quality neutral zone — t4/t5 pools, highest-challenge encounters: dragon utopias,
+    /// unstable ruins, research labs, mythic scroll boxes, tier-3 hero stats, many unit banks
+    /// (including biome-restricted), legendary loot, many pandora boxes, gold-heavy mines.
+    /// Based on t4/t5-pool treasure zones found in Staircase, Symphony, Blitz, Crossroads, and
+    /// high-zone mandatory content across the example template corpus.
+    /// Only this tier spawns dragon utopias, unstable ruins, and research laboratories.
+    /// </summary>
+    public static List<ContentItem> BuildHighNeutralMandatoryContent(int castleCount, bool spawnFootholds)
+    {
+        var content = new List<ContentItem>();
+
+        if (spawnFootholds)
+            content.Add(ContentPresets.RemoteFoothold(castleCount));
+
+        content.AddRange([
+            // Epic encounters — exclusive to high zones.
+            new() { IncludeLists = ["content_list_building_utopia"] },
+            new() { IncludeLists = ["content_list_building_utopia"] },
+            new() { IncludeLists = ["content_list_building_epic_guarded_resource_banks"] },
+            new() { IncludeLists = ["content_list_building_epic_guarded_resource_banks"] },
+            // Utility — vision + buff buildings.
+            new() { IncludeLists = ["basic_content_list_vision_buildings_tier_1"] },
+            new() { IncludeLists = ["basic_content_list_building_hero_buff_tier_1"] },
+            // Hero stats — tier 2 + tier 3 (fort/university/maze/college_of_wonder).
+            new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_2"] },
+            new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_3"] },
+            new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_3"] },
+            // Magic buildings — tier 2 (magic amplifiers).
+            new() { IncludeLists = ["basic_content_list_building_magic_tier_2"] },
+            new() { IncludeLists = ["basic_content_list_building_magic_tier_2"] },
+            // Hiring — high-tier hires (hires 5–7) + all hires pool.
+            new() { IncludeLists = ["content_list_building_random_hires_high_tier"] },
+            new() { IncludeLists = ["content_list_building_random_hires_high_tier"] },
+            new() { IncludeLists = ["basic_content_list_building_random_hires"] },
+            // Unit banks — biome-restricted + no-restriction variants.
+            new() { IncludeLists = ["basic_content_list_building_guarded_units_banks_only_biome_restriction"] },
+            new() { IncludeLists = ["basic_content_list_building_guarded_units_banks_no_biome_restriction"] },
+            new() { IncludeLists = ["basic_content_list_building_guarded_units_banks_no_biome_restriction"] },
+            // Guarded resource banks — tier 2 + tier 3.
+            new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_2"] },
+            new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_3"] },
+            // Loot — mythic scrolls, legendary items, pandora boxes with high-tier armies.
+            new() { IncludeLists = ["basic_content_list_pickup_mythic_scroll_box"] },
+            new() { IncludeLists = ["basic_content_list_pickup_mythic_scroll_box"] },
+            ContentItemBuilder.Create(ContentIds.RandomItemLegendary).SoloEncounter().Build(),
+            ContentItemBuilder.Create(ContentIds.RandomItemLegendary).Build(),
+            ContentItemBuilder.Create(ContentIds.RandomItemEpic).Build(),
+            ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
+            ContentItemBuilder.Create(ContentIds.PandoraBox).Build(),
+            ContentItemBuilder.Create(ContentIds.PandoraBox).Build(),
+            new() { IncludeLists = ["content_list_pickup_pandora_box_army_high_tier"] },
+            new() { IncludeLists = ["content_list_pickup_pandora_box_army_high_tier"] },
+            // Mines — gold-heavy with full rare set.
+            ContentPresets.MineGold_NearCrossroads(),
+            ContentItemBuilder.Create(ContentIds.MineGold).Mine().Build(),
+            ContentItemBuilder.Create(ContentIds.MineGold).Mine().Build(),
+            ContentItemBuilder.Create(ContentIds.MineCrystals).Mine().Build(),
+            ContentItemBuilder.Create(ContentIds.MineMercury).Mine().Build(),
+            ContentItemBuilder.Create(ContentIds.MineGemstones).Mine().Build(),
+            ContentItemBuilder.Create(ContentIds.AlchemyLab).Mine().Build(),
+            ContentItemBuilder.Create(ContentIds.AlchemyLab).Mine().Build(),
+        ]);
+
+        return content;
+    }
+}
+}

--- a/Olden Era - Template Editor/Services/TemplateGenerator.cs
+++ b/Olden Era - Template Editor/Services/TemplateGenerator.cs
@@ -2139,8 +2139,8 @@ namespace Olden_Era___Template_Editor.Services
                     From = fromZone,
                     To = toZone,
                     ConnectionType = "Portal",
-                    PortalPlacementRulesFrom = [RulePresets.AtCrossroads(min:0.1, max:0.3, weight:2)],
-                    PortalPlacementRulesTo   = [RulePresets.AtCrossroads(min:0.1, max:0.3, weight:2)],
+                    PortalPlacementRulesFrom = [RulePresets.CrossroadsDistance(DistancePresets.Near, weight:2)],
+                    PortalPlacementRulesTo   = [RulePresets.CrossroadsDistance(DistancePresets.Near, weight:2)],
                     Road = true,
                     GuardEscape = false,
                     GuardValue = ScaleBorderGuardValue(25000, tuning),
@@ -2341,7 +2341,7 @@ namespace Olden_Era___Template_Editor.Services
             return new MandatoryContentGroup
             {
                 Name = $"mandatory_content_side_{letter}",
-                Content = BuildPlayerZoneMandatoryContent(castleCount, spawnFootholds)
+                Content = ZoneContentManager.BuildPlayerZoneMandatoryContent(castleCount, spawnFootholds)
             };
         }
 
@@ -2352,223 +2352,11 @@ namespace Olden_Era___Template_Editor.Services
                 Name = $"mandatory_content_neutral_{letter}",
                 Content = quality switch
                 {
-                    NeutralZoneQuality.Low    => BuildLowNeutralMandatoryContent(castleCount, spawnFootholds),
-                    NeutralZoneQuality.High   => BuildHighNeutralMandatoryContent(castleCount, spawnFootholds),
-                    _                         => BuildMediumNeutralMandatoryContent(castleCount, spawnFootholds),
+                    NeutralZoneQuality.Low    => ZoneContentManager.BuildLowNeutralMandatoryContent(castleCount, spawnFootholds),
+                    NeutralZoneQuality.High   => ZoneContentManager.BuildHighNeutralMandatoryContent(castleCount, spawnFootholds),
+                    _                         => ZoneContentManager.BuildMediumNeutralMandatoryContent(castleCount, spawnFootholds),
                 }
             };
-        }
-
-        /// <summary>
-        /// Player spawn zone — guaranteed starter mines anchored near the castle, a full rare mine
-        /// set spread along roads, utility/economic buildings, tier-split hiring picks, one hero
-        /// stat trainer, guarded resource banks, and starter loot.
-        /// Grounded in the consensus across Exodus, Staircase, Kerberos, Blitz, Universe, and
-        /// Yin Yang spawn zones from the example template corpus.
-        /// </summary>
-        private static List<ContentItem> BuildPlayerZoneMandatoryContent(int castleCount, bool spawnFootholds)
-        {
-            var content = new List<ContentItem>();
-
-            if (spawnFootholds)
-                content.Add(ContentPresets.RemoteFoothold(castleCount));
-
-            content.AddRange([
-                // ── Basic mines — guarded, anchored near the player castle (every template). ──
-                ContentPresets.MineWood_Anchored(),
-                ContentPresets.MineOre_Anchored(),
-                // ── Gold mine near crossroads (Exodus/Staircase/Yin Yang pattern). ──
-                ContentPresets.MineGold_Crossroads(),
-                // ── Rare mines spread along roads (Exodus/Staircase/Yin Yang pattern). ──
-                ContentPresets.MineCrystals_Road(),
-                ContentPresets.MineMercury_Road(),
-                ContentPresets.MineGemstones_Road(),
-                ContentPresets.AlchemyLab_Road(),
-                // ── Utility buildings (Blitz/Kerberos/Exodus pattern). ──
-                new() { Sid = "watchtower" },
-                ContentItemBuilder.Create(ContentIds.Market).Guarded().AddRule(RulePresets.NearRoad(min:0.15, max:0.30)).Build(),
-                ContentItemBuilder.Create(ContentIds.ManaWell).AddRule(RulePresets.NearRoad(min:0.15, max:0.30)).Build(),
-                // ── Hero training — tier-2 stat building (fort/university/orb_observatory) ──
-                //    + uncommon hero bank (university/wise_owl/tree_of_knowledge) (Blitz/Exodus pattern).
-                new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_2"] },
-                new() { IncludeLists = ["content_list_building_uncommon_hero_banks"] },
-
-                // ── Hiring — low-tier × 2 + high-tier × 1 + full pool × 1 (Kerberos + Universe blend). ──
-                new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
-                new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
-                new() { IncludeLists = ["content_list_building_random_hires_high_tier"] },
-                new() { IncludeLists = ["basic_content_list_building_random_hires"] },
-
-                // ── Guarded resource banks — tier 1 × 2 + tier 2 × 1 (Exodus pattern). ──
-                new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_1"] },
-                new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_1"] },
-                new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_2"] },
-
-                // ── Loot — epic items + army pandora (Exodus/Blitz pattern). ──
-                ContentItemBuilder.Create(ContentIds.RandomItemEpic).SoloEncounter().Build(),
-                ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
-                new() { IncludeLists = ["content_list_pickup_pandora_box_army_low_tier"] },
-            ]);
-
-            return content;
-        }
-
-        /// <summary>
-        /// Low-quality neutral zone — t2 pools, intentionally lean mandatory content.
-        /// The t2 content pools supply most of the variety; mandatory content only guarantees
-        /// the essential items that every low zone must have: a few rare mines, basic utility
-        /// buildings, and a handful of random hires. Modelled after Universe side zones,
-        /// Kerberos connector zones, and Madness side zones from the template corpus.
-        /// No high-end encounters (no dragon utopias, research labs, unstable ruins).
-        /// </summary>
-        private static List<ContentItem> BuildLowNeutralMandatoryContent(int castleCount, bool spawnFootholds)
-        {
-            var content = new List<ContentItem>();
-
-            if (spawnFootholds)
-                content.Add(ContentPresets.RemoteFoothold(castleCount));
-
-            content.AddRange([
-                // Mines — biome-based rare mine + one fixed rare mine (Blitz Side-1 pattern).
-                new() { Name = "name_mine_by_biome_1", IncludeLists = ["basic_content_list_rare_mines_by_biome"], IsMine = true },
-                new() { IncludeLists = ["basic_content_list_rare_mines"], IsMine = true },
-                // Utility — one guarded market near crossroads, one vision building.
-                ContentItemBuilder.Create(ContentIds.Market).Guarded().AddRule(RulePresets.AtCrossroads(min:0.15, max:0.20)).Build(),
-                new() { IncludeLists = ["basic_content_list_vision_buildings_tier_1"] },
-                // Buff buildings — picked from the real hero-buff pool (mana_well, fountain, stables, etc.).
-                new() { IncludeLists = ["basic_content_list_building_hero_buff_tier_1"] },
-                new() { IncludeLists = ["basic_content_list_building_hero_buff_tier_1"] },
-                // Common hero stat building (stinging_sword, armory_automaton, magic_wheel, knowledge_garden).
-                new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_1"] },
-                // Hiring — low-tier random hires (hires 1–4, confirmed content_list name).
-                new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
-                new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
-                // Loot — solo pandora box + low-tier army pandora (variants 8–11).
-                ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
-                new() { IncludeLists = ["content_list_pickup_pandora_box_army_low_tier"] },
-                // Pickup — random item + common magic pickup.
-                new() { IncludeLists = ["basic_content_list_pickup_random_items"] },
-                new() { IncludeLists = ["basic_content_list_building_magic_tier_1"] },
-            ]);
-
-            return content;
-        }
-
-        /// <summary>
-        /// Medium-quality neutral zone — t3 pools, tier-3 resource banks, medium hires, stat buildings,
-        /// epic+legendary loot, pandora boxes, gold and rare mines.
-        /// Based on t3-pool side/treasure zones found in Staircase, Shamrock, Blitz, Kerberos, and similar templates.
-        /// No high-end encounters (no dragon utopias, research labs, unstable ruins).
-        /// </summary>
-        private static List<ContentItem> BuildMediumNeutralMandatoryContent(int castleCount, bool spawnFootholds)
-        {
-            var content = new List<ContentItem>();
-
-            if (spawnFootholds)
-                content.Add(ContentPresets.RemoteFoothold(castleCount));
-
-            content.AddRange([
-                // Mines — full rare set + gold + alchemy lab (Yin Yang/Staircase t3 pattern).
-                ContentPresets.MineCrystals_Road(),
-                ContentPresets.MineMercury_Road(),
-                ContentPresets.MineGemstones_Road(),
-                ContentPresets.AlchemyLab_Road(),
-                ContentItemBuilder.Create(ContentIds.MineGold).Mine().AddRule(RulePresets.NearRoad(min:0.15, max:0.20)).Build(),
-                // Utility — watchtower (guarded) + vision building (tier 1 only: flattering_mirror/watchtower).
-                // wind_rose (full map reveal) lives in tier_2 and belongs exclusively in high zones.
-                ContentItemBuilder.Create(ContentIds.Watchtower).Guarded().Build(),
-                new() { IncludeLists = ["basic_content_list_vision_buildings_tier_1"] },
-                // Buff buildings.
-                new() { IncludeLists = ["basic_content_list_building_hero_buff_tier_1"] },
-                // Hero stats — tier 1 common + tier 2 uncommon picks.
-                new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_1"] },
-                new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_2"] },
-                // Magic buildings — tier 1 + tier 2.
-                new() { IncludeLists = ["basic_content_list_building_magic_tier_1"] },
-                new() { IncludeLists = ["basic_content_list_building_magic_tier_2"] },
-                // Hiring — low-tier + high-tier random hires (confirmed generator list names).
-                new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
-                new() { IncludeLists = ["content_list_building_random_hires_high_tier"] },
-                // Unit banks — biome-restricted (Blitz Treasure-2 pattern).
-                new() { IncludeLists = ["basic_content_list_building_guarded_units_banks_only_biome_restriction"] },
-                // Guarded resource banks — tier 2 (no black tower / tier-1 banks).
-                new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_2"] },
-                // Loot — epic items + pandora boxes with army variants.
-                ContentItemBuilder.Create(ContentIds.RandomItemEpic).SoloEncounter().Build(),
-                ContentItemBuilder.Create(ContentIds.RandomItemEpic).Build(),
-                ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
-                ContentItemBuilder.Create(ContentIds.PandoraBox).Build(),
-                new() { IncludeLists = ["content_list_pickup_pandora_box_army_low_tier"] },
-            ]);
-
-            return content;
-        }
-
-        /// <summary>
-        /// High-quality neutral zone — t4/t5 pools, highest-challenge encounters: dragon utopias,
-        /// unstable ruins, research labs, mythic scroll boxes, tier-3 hero stats, many unit banks
-        /// (including biome-restricted), legendary loot, many pandora boxes, gold-heavy mines.
-        /// Based on t4/t5-pool treasure zones found in Staircase, Symphony, Blitz, Crossroads, and
-        /// high-zone mandatory content across the example template corpus.
-        /// Only this tier spawns dragon utopias, unstable ruins, and research laboratories.
-        /// </summary>
-        private static List<ContentItem> BuildHighNeutralMandatoryContent(int castleCount, bool spawnFootholds)
-        {
-            var content = new List<ContentItem>();
-
-            if (spawnFootholds)
-                content.Add(ContentPresets.RemoteFoothold(castleCount));
-
-            content.AddRange([
-                // Epic encounters — exclusive to high zones.
-                new() { IncludeLists = ["content_list_building_utopia"] },
-                new() { IncludeLists = ["content_list_building_utopia"] },
-                new() { IncludeLists = ["content_list_building_epic_guarded_resource_banks"] },
-                new() { IncludeLists = ["content_list_building_epic_guarded_resource_banks"] },
-                // Utility — vision + buff buildings.
-                new() { IncludeLists = ["basic_content_list_vision_buildings_tier_1"] },
-                new() { IncludeLists = ["basic_content_list_building_hero_buff_tier_1"] },
-                // Hero stats — tier 2 + tier 3 (fort/university/maze/college_of_wonder).
-                new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_2"] },
-                new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_3"] },
-                new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_3"] },
-                // Magic buildings — tier 2 (magic amplifiers).
-                new() { IncludeLists = ["basic_content_list_building_magic_tier_2"] },
-                new() { IncludeLists = ["basic_content_list_building_magic_tier_2"] },
-                // Hiring — high-tier hires (hires 5–7) + all hires pool.
-                new() { IncludeLists = ["content_list_building_random_hires_high_tier"] },
-                new() { IncludeLists = ["content_list_building_random_hires_high_tier"] },
-                new() { IncludeLists = ["basic_content_list_building_random_hires"] },
-                // Unit banks — biome-restricted + no-restriction variants.
-                new() { IncludeLists = ["basic_content_list_building_guarded_units_banks_only_biome_restriction"] },
-                new() { IncludeLists = ["basic_content_list_building_guarded_units_banks_no_biome_restriction"] },
-                new() { IncludeLists = ["basic_content_list_building_guarded_units_banks_no_biome_restriction"] },
-                // Guarded resource banks — tier 2 + tier 3.
-                new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_2"] },
-                new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_3"] },
-                // Loot — mythic scrolls, legendary items, pandora boxes with high-tier armies.
-                new() { IncludeLists = ["basic_content_list_pickup_mythic_scroll_box"] },
-                new() { IncludeLists = ["basic_content_list_pickup_mythic_scroll_box"] },
-                ContentItemBuilder.Create(ContentIds.RandomItemLegendary).SoloEncounter().Build(),
-                ContentItemBuilder.Create(ContentIds.RandomItemLegendary).Build(),
-                ContentItemBuilder.Create(ContentIds.RandomItemEpic).Build(),
-                ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
-                ContentItemBuilder.Create(ContentIds.PandoraBox).Build(),
-                ContentItemBuilder.Create(ContentIds.PandoraBox).Build(),
-                new() { IncludeLists = ["content_list_pickup_pandora_box_army_high_tier"] },
-                new() { IncludeLists = ["content_list_pickup_pandora_box_army_high_tier"] },
-                // Mines — gold-heavy with full rare set.
-                ContentPresets.MineGold_Crossroads(),
-                ContentItemBuilder.Create(ContentIds.MineGold).Mine().Build(),
-                ContentItemBuilder.Create(ContentIds.MineGold).Mine().Build(),
-                ContentItemBuilder.Create(ContentIds.MineCrystals).Mine().Build(),
-                ContentItemBuilder.Create(ContentIds.MineMercury).Mine().Build(),
-                ContentItemBuilder.Create(ContentIds.MineGemstones).Mine().Build(),
-                ContentItemBuilder.Create(ContentIds.AlchemyLab).Mine().Build(),
-                ContentItemBuilder.Create(ContentIds.AlchemyLab).Mine().Build(),
-            ]);
-
-            return content;
         }
 
         // ── Content count limits ─────────────────────────────────────────────────

--- a/Olden Era - Template Editor/Services/TemplateGenerator.cs
+++ b/Olden Era - Template Editor/Services/TemplateGenerator.cs
@@ -1,5 +1,6 @@
 using Olden_Era___Template_Editor.Models;
 using OldenEraTemplateEditor.Models;
+using OldenEraTemplateEditor.Services.ContentManagement;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -2138,8 +2139,8 @@ namespace Olden_Era___Template_Editor.Services
                     From = fromZone,
                     To = toZone,
                     ConnectionType = "Portal",
-                    PortalPlacementRulesFrom = [new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = 0.1, TargetMax = 0.3, Weight = 2 }],
-                    PortalPlacementRulesTo   = [new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = 0.1, TargetMax = 0.3, Weight = 2 }],
+                    PortalPlacementRulesFrom = [RulePresets.AtCrossroads(min:0.1, max:0.3, weight:2)],
+                    PortalPlacementRulesTo   = [RulePresets.AtCrossroads(min:0.1, max:0.3, weight:2)],
                     Road = true,
                     GuardEscape = false,
                     GuardValue = ScaleBorderGuardValue(25000, tuning),
@@ -2367,38 +2368,26 @@ namespace Olden_Era___Template_Editor.Services
         /// </summary>
         private static List<ContentItem> BuildPlayerZoneMandatoryContent(int castleCount, bool spawnFootholds)
         {
-            var footholdRules = FootholdRules(castleCount);
             var content = new List<ContentItem>();
 
             if (spawnFootholds)
-                content.Add(new ContentItem { Name = "name_remote_foothold_1", Sid = "remote_foothold", IsGuarded = false, Rules = footholdRules });
+                content.Add(ContentPresets.RemoteFoothold(castleCount));
 
             content.AddRange([
                 // ── Basic mines — guarded, anchored near the player castle (every template). ──
-                new() { Name = "name_mine_wood", Sid = "mine_wood", IsMine = true, IsGuarded = true,
-                    Rules = [new ContentPlacementRule { Type = "MainObject", Args = ["0"], TargetMin = 0.15, TargetMax = 0.35, Weight = 1 },
-                             new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = 0.15, TargetMax = 0.30, Weight = 1 }] },
-                new() { Name = "name_mine_ore",  Sid = "mine_ore",  IsMine = true, IsGuarded = true,
-                    Rules = [new ContentPlacementRule { Type = "MainObject", Args = ["0"], TargetMin = 0.15, TargetMax = 0.35, Weight = 1 },
-                             new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = 0.15, TargetMax = 0.30, Weight = 1 }] },
-
+                ContentPresets.MineWood_Anchored(),
+                ContentPresets.MineOre_Anchored(),
                 // ── Gold mine near crossroads (Exodus/Staircase/Yin Yang pattern). ──
-                new() { Sid = "mine_gold", IsMine = true,
-                    Rules = [new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = 0.10, TargetMax = 0.30, Weight = 1 }] },
-
+                ContentPresets.MineGold_Crossroads(),
                 // ── Rare mines spread along roads (Exodus/Staircase/Yin Yang pattern). ──
-                new() { Name = "name_mine_crystals",  Sid = "mine_crystals",  IsMine = true, Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.05, TargetMax = 0.10, Weight = 1 }] },
-                new() { Name = "name_mine_mercury",   Sid = "mine_mercury",   IsMine = true, Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.05, TargetMax = 0.10, Weight = 1 }] },
-                new() { Name = "name_mine_gemstones", Sid = "mine_gemstones", IsMine = true, Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.05, TargetMax = 0.10, Weight = 1 }] },
-                new() { Name = "name_alchemy_lab",    Sid = "alchemy_lab",    IsMine = true, Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.20, TargetMax = 0.30, Weight = 1 }] },
-
+                ContentPresets.MineCrystals_Road(),
+                ContentPresets.MineMercury_Road(),
+                ContentPresets.MineGemstones_Road(),
+                ContentPresets.AlchemyLab_Road(),
                 // ── Utility buildings (Blitz/Kerberos/Exodus pattern). ──
                 new() { Sid = "watchtower" },
-                new() { Sid = "market", IsGuarded = true,
-                    Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.15, TargetMax = 0.30, Weight = 1 }] },
-                new() { Sid = "mana_well",
-                    Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.15, TargetMax = 0.30, Weight = 1 }] },
-
+                ContentItemBuilder.Create(ContentIds.Market).Guarded().AddRule(RulePresets.NearRoad(min:0.15, max:0.30)).Build(),
+                ContentItemBuilder.Create(ContentIds.ManaWell).AddRule(RulePresets.NearRoad(min:0.15, max:0.30)).Build(),
                 // ── Hero training — tier-2 stat building (fort/university/orb_observatory) ──
                 //    + uncommon hero bank (university/wise_owl/tree_of_knowledge) (Blitz/Exodus pattern).
                 new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_2"] },
@@ -2416,8 +2405,8 @@ namespace Olden_Era___Template_Editor.Services
                 new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_2"] },
 
                 // ── Loot — epic items + army pandora (Exodus/Blitz pattern). ──
-                new() { Sid = "random_item_epic", SoloEncounter = true },
-                new() { Sid = "pandora_box", SoloEncounter = true },
+                ContentItemBuilder.Create(ContentIds.RandomItemEpic).SoloEncounter().Build(),
+                ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
                 new() { IncludeLists = ["content_list_pickup_pandora_box_army_low_tier"] },
             ]);
 
@@ -2434,18 +2423,17 @@ namespace Olden_Era___Template_Editor.Services
         /// </summary>
         private static List<ContentItem> BuildLowNeutralMandatoryContent(int castleCount, bool spawnFootholds)
         {
-            var footholdRules = FootholdRules(castleCount);
             var content = new List<ContentItem>();
 
             if (spawnFootholds)
-                content.Add(new ContentItem { Name = "name_remote_foothold_1", Sid = "remote_foothold", IsGuarded = false, Rules = footholdRules });
+                content.Add(ContentPresets.RemoteFoothold(castleCount));
 
             content.AddRange([
                 // Mines — biome-based rare mine + one fixed rare mine (Blitz Side-1 pattern).
                 new() { Name = "name_mine_by_biome_1", IncludeLists = ["basic_content_list_rare_mines_by_biome"], IsMine = true },
                 new() { IncludeLists = ["basic_content_list_rare_mines"], IsMine = true },
                 // Utility — one guarded market near crossroads, one vision building.
-                new() { Sid = "market", IsGuarded = true, Rules = [new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = 0.15, TargetMax = 0.20, Weight = 1 }] },
+                ContentItemBuilder.Create(ContentIds.Market).Guarded().AddRule(RulePresets.AtCrossroads(min:0.15, max:0.20)).Build(),
                 new() { IncludeLists = ["basic_content_list_vision_buildings_tier_1"] },
                 // Buff buildings — picked from the real hero-buff pool (mana_well, fountain, stables, etc.).
                 new() { IncludeLists = ["basic_content_list_building_hero_buff_tier_1"] },
@@ -2456,7 +2444,7 @@ namespace Olden_Era___Template_Editor.Services
                 new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
                 new() { IncludeLists = ["content_list_building_random_hires_low_tier"] },
                 // Loot — solo pandora box + low-tier army pandora (variants 8–11).
-                new() { Sid = "pandora_box", SoloEncounter = true },
+                ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
                 new() { IncludeLists = ["content_list_pickup_pandora_box_army_low_tier"] },
                 // Pickup — random item + common magic pickup.
                 new() { IncludeLists = ["basic_content_list_pickup_random_items"] },
@@ -2474,22 +2462,21 @@ namespace Olden_Era___Template_Editor.Services
         /// </summary>
         private static List<ContentItem> BuildMediumNeutralMandatoryContent(int castleCount, bool spawnFootholds)
         {
-            var footholdRules = FootholdRules(castleCount);
             var content = new List<ContentItem>();
 
             if (spawnFootholds)
-                content.Add(new ContentItem { Name = "name_remote_foothold_1", Sid = "remote_foothold", IsGuarded = false, Rules = footholdRules });
+                content.Add(ContentPresets.RemoteFoothold(castleCount));
 
             content.AddRange([
                 // Mines — full rare set + gold + alchemy lab (Yin Yang/Staircase t3 pattern).
-                new() { Name = "name_mine_crystals", Sid = "mine_crystals",  IsMine = true, Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.05, TargetMax = 0.10, Weight = 1 }] },
-                new() { Name = "name_mine_mercury",  Sid = "mine_mercury",   IsMine = true, Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.05, TargetMax = 0.10, Weight = 1 }] },
-                new() { Name = "name_mine_gemstones",Sid = "mine_gemstones", IsMine = true, Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.05, TargetMax = 0.10, Weight = 1 }] },
-                new() { Sid = "mine_gold",    IsMine = true, Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.15, TargetMax = 0.20, Weight = 1 }] },
-                new() { Sid = "alchemy_lab",  IsMine = true, Rules = [new ContentPlacementRule { Type = "Road", Args = [], TargetMin = 0.20, TargetMax = 0.30, Weight = 1 }] },
+                ContentPresets.MineCrystals_Road(),
+                ContentPresets.MineMercury_Road(),
+                ContentPresets.MineGemstones_Road(),
+                ContentPresets.AlchemyLab_Road(),
+                ContentItemBuilder.Create(ContentIds.MineGold).Mine().AddRule(RulePresets.NearRoad(min:0.15, max:0.20)).Build(),
                 // Utility — watchtower (guarded) + vision building (tier 1 only: flattering_mirror/watchtower).
                 // wind_rose (full map reveal) lives in tier_2 and belongs exclusively in high zones.
-                new() { Sid = "watchtower", IsGuarded = true },
+                ContentItemBuilder.Create(ContentIds.Watchtower).Guarded().Build(),
                 new() { IncludeLists = ["basic_content_list_vision_buildings_tier_1"] },
                 // Buff buildings.
                 new() { IncludeLists = ["basic_content_list_building_hero_buff_tier_1"] },
@@ -2507,10 +2494,10 @@ namespace Olden_Era___Template_Editor.Services
                 // Guarded resource banks — tier 2 (no black tower / tier-1 banks).
                 new() { IncludeLists = ["basic_content_list_building_guarded_resource_banks_tier_2"] },
                 // Loot — epic items + pandora boxes with army variants.
-                new() { Sid = "random_item_epic", SoloEncounter = true },
-                new() { Sid = "random_item_epic" },
-                new() { Sid = "pandora_box", SoloEncounter = true },
-                new() { Sid = "pandora_box" },
+                ContentItemBuilder.Create(ContentIds.RandomItemEpic).SoloEncounter().Build(),
+                ContentItemBuilder.Create(ContentIds.RandomItemEpic).Build(),
+                ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
+                ContentItemBuilder.Create(ContentIds.PandoraBox).Build(),
                 new() { IncludeLists = ["content_list_pickup_pandora_box_army_low_tier"] },
             ]);
 
@@ -2527,11 +2514,10 @@ namespace Olden_Era___Template_Editor.Services
         /// </summary>
         private static List<ContentItem> BuildHighNeutralMandatoryContent(int castleCount, bool spawnFootholds)
         {
-            var footholdRules = FootholdRules(castleCount);
             var content = new List<ContentItem>();
 
             if (spawnFootholds)
-                content.Add(new ContentItem { Name = "name_remote_foothold_1", Sid = "remote_foothold", IsGuarded = false, Rules = footholdRules });
+                content.Add(ContentPresets.RemoteFoothold(castleCount));
 
             content.AddRange([
                 // Epic encounters — exclusive to high zones.
@@ -2563,39 +2549,26 @@ namespace Olden_Era___Template_Editor.Services
                 // Loot — mythic scrolls, legendary items, pandora boxes with high-tier armies.
                 new() { IncludeLists = ["basic_content_list_pickup_mythic_scroll_box"] },
                 new() { IncludeLists = ["basic_content_list_pickup_mythic_scroll_box"] },
-                new() { Sid = "random_item_legendary", SoloEncounter = true },
-                new() { Sid = "random_item_legendary" },
-                new() { Sid = "random_item_epic" },
-                new() { Sid = "pandora_box", SoloEncounter = true },
-                new() { Sid = "pandora_box" },
-                new() { Sid = "pandora_box" },
+                ContentItemBuilder.Create(ContentIds.RandomItemLegendary).SoloEncounter().Build(),
+                ContentItemBuilder.Create(ContentIds.RandomItemLegendary).Build(),
+                ContentItemBuilder.Create(ContentIds.RandomItemEpic).Build(),
+                ContentItemBuilder.Create(ContentIds.PandoraBox).SoloEncounter().Build(),
+                ContentItemBuilder.Create(ContentIds.PandoraBox).Build(),
+                ContentItemBuilder.Create(ContentIds.PandoraBox).Build(),
                 new() { IncludeLists = ["content_list_pickup_pandora_box_army_high_tier"] },
                 new() { IncludeLists = ["content_list_pickup_pandora_box_army_high_tier"] },
                 // Mines — gold-heavy with full rare set.
-                new() { Sid = "mine_gold",      IsMine = true, Rules = [new ContentPlacementRule { Type = "Crossroads", Args = [], TargetMin = 0.1, TargetMax = 0.3, Weight = 1 }] },
-                new() { Sid = "mine_gold",      IsMine = true },
-                new() { Sid = "mine_gold",      IsMine = true },
-                new() { Sid = "mine_crystals",  IsMine = true },
-                new() { Sid = "mine_mercury",   IsMine = true },
-                new() { Sid = "mine_gemstones", IsMine = true },
-                new() { Sid = "alchemy_lab",    IsMine = true },
-                new() { Sid = "alchemy_lab",    IsMine = true },
+                ContentPresets.MineGold_Crossroads(),
+                ContentItemBuilder.Create(ContentIds.MineGold).Mine().Build(),
+                ContentItemBuilder.Create(ContentIds.MineGold).Mine().Build(),
+                ContentItemBuilder.Create(ContentIds.MineCrystals).Mine().Build(),
+                ContentItemBuilder.Create(ContentIds.MineMercury).Mine().Build(),
+                ContentItemBuilder.Create(ContentIds.MineGemstones).Mine().Build(),
+                ContentItemBuilder.Create(ContentIds.AlchemyLab).Mine().Build(),
+                ContentItemBuilder.Create(ContentIds.AlchemyLab).Mine().Build(),
             ]);
 
             return content;
-        }
-
-        private static List<ContentPlacementRule> FootholdRules(int castleCount)
-        {
-            var rules = new List<ContentPlacementRule>
-            {
-                new() { Type = "Crossroads", Args = [], TargetMin = 0.2, TargetMax = 0.3, Weight = 0 },
-            };
-            if (castleCount > 0)
-                rules.Add(new ContentPlacementRule { Type = "MainObject", Args = ["0"], TargetMin = 0.2, TargetMax = 0.4, Weight = 0 });
-            if (castleCount > 1)
-                rules.Add(new ContentPlacementRule { Type = "MainObject", Args = ["1"], TargetMin = 0.5, TargetMax = 0.5, Weight = 2 });
-            return rules;
         }
 
         // ── Content count limits ─────────────────────────────────────────────────
@@ -2609,62 +2582,63 @@ namespace Olden_Era___Template_Editor.Services
             var sidLimits = new List<ContentSidLimit>
             {
                 // ── Banned in generated zones ────────────────────────────────────
+                // black_tower sid is missing from the known values content list. To be investigated...
                 new() { Sid = "black_tower",          MaxCount = 0 }, // tier-1 resource bank; too weak/out-of-place in neutral zones
                 // ── Utility / buff buildings ─────────────────────────────────────
-                new() { Sid = "fountain",             MaxCount = 2 },
-                new() { Sid = "fountain_2",           MaxCount = 2 },
-                new() { Sid = "mana_well",            MaxCount = 2 },
-                new() { Sid = "beer_fountain",        MaxCount = 2 },
-                new() { Sid = "market",               MaxCount = 1 },
-                new() { Sid = "forge",                MaxCount = 2 },
-                new() { Sid = "stables",              MaxCount = 1 },
-                new() { Sid = "watchtower",           MaxCount = 2 },
-                new() { Sid = "wind_rose",            MaxCount = 1 },
-                new() { Sid = "quixs_path",           MaxCount = 2 },
-                new() { Sid = "crystal_trail",        MaxCount = 3 },
-                new() { Sid = "mysterious_stone",     MaxCount = 2 },
+                new() { Sid = ContentIds.Fountain,             MaxCount = 2 },
+                new() { Sid = ContentIds.Fountain2,           MaxCount = 2 },
+                new() { Sid = ContentIds.ManaWell,            MaxCount = 2 },
+                new() { Sid = ContentIds.BeerFountain,        MaxCount = 2 },
+                new() { Sid = ContentIds.Market,               MaxCount = 1 },
+                new() { Sid = ContentIds.Forge,                MaxCount = 2 },
+                new() { Sid = ContentIds.Stables,              MaxCount = 1 },
+                new() { Sid = ContentIds.Watchtower,           MaxCount = 2 },
+                new() { Sid = ContentIds.WindRose,            MaxCount = 1 },
+                new() { Sid = ContentIds.QuixsPath,           MaxCount = 2 },
+                new() { Sid = ContentIds.CrystalTrail,        MaxCount = 3 },
+                new() { Sid = ContentIds.MysteriousStone,     MaxCount = 2 },
 
                 // ── Learning / XP buildings ──────────────────────────────────────
-                new() { Sid = "university",           MaxCount = 2 },
-                new() { Sid = "wise_owl",             MaxCount = 4 },
-                new() { Sid = "celestial_sphere",     MaxCount = 2 },
-                new() { Sid = "pile_of_books",        MaxCount = 2 },
-                new() { Sid = "insaras_eye",          MaxCount = 2 },
-                new() { Sid = "tear_of_truth",        MaxCount = 3 },
-                new() { Sid = "tree_of_abundance",    MaxCount = 2 },
+                new() { Sid = ContentIds.University,           MaxCount = 2 },
+                new() { Sid = ContentIds.WiseOwl,             MaxCount = 4 },
+                new() { Sid = ContentIds.CelestialSphere,     MaxCount = 2 },
+                new() { Sid = ContentIds.PileOfBooks,        MaxCount = 2 },
+                new() { Sid = ContentIds.InsarasEye,          MaxCount = 2 },
+                new() { Sid = ContentIds.TearOfTruth,        MaxCount = 3 },
+                new() { Sid = ContentIds.TreeOfAbundance,    MaxCount = 2 },
 
                 // ── Hire buildings ───────────────────────────────────────────────
-                new() { Sid = "huntsmans_camp",       MaxCount = 2 },
-                new() { Sid = "shady_den",            MaxCount = 2 },
-                new() { Sid = "random_hire_1",        MaxCount = 6 },
-                new() { Sid = "random_hire_2",        MaxCount = 6 },
-                new() { Sid = "random_hire_3",        MaxCount = 6 },
-                new() { Sid = "random_hire_4",        MaxCount = 6 },
-                new() { Sid = "random_hire_5",        MaxCount = 6 },
-                new() { Sid = "random_hire_6",        MaxCount = 6 },
-                new() { Sid = "random_hire_7",        MaxCount = 6 },
+                new() { Sid = ContentIds.HuntsmansCamp,       MaxCount = 2 },
+                new() { Sid = ContentIds.ShadyDen,            MaxCount = 2 },
+                new() { Sid = ContentIds.RandomHire1,        MaxCount = 6 },
+                new() { Sid = ContentIds.RandomHire2,        MaxCount = 6 },
+                new() { Sid = ContentIds.RandomHire3,        MaxCount = 6 },
+                new() { Sid = ContentIds.RandomHire4,        MaxCount = 6 },
+                new() { Sid = ContentIds.RandomHire5,        MaxCount = 6 },
+                new() { Sid = ContentIds.RandomHire6,        MaxCount = 6 },
+                new() { Sid = ContentIds.RandomHire7,        MaxCount = 6 },
 
                 // ── Combat / encounter buildings ─────────────────────────────────
-                new() { Sid = "arena",                MaxCount = 2 },
-                new() { Sid = "sacrificial_shrine",   MaxCount = 2 },
-                new() { Sid = "chimerologist",        MaxCount = 2 },
-                new() { Sid = "circus",               MaxCount = 2 },
-                new() { Sid = "infernal_cirque",      MaxCount = 2 },
-                new() { Sid = "flattering_mirror",    MaxCount = 2 },
-                new() { Sid = "fickle_shrine",        MaxCount = 1 },
-                new() { Sid = "point_of_balance",     MaxCount = 3 },
+                new() { Sid = ContentIds.Arena,                MaxCount = 2 },
+                new() { Sid = ContentIds.SacrificialShrine,   MaxCount = 2 },
+                new() { Sid = ContentIds.Chimerologist,        MaxCount = 2 },
+                new() { Sid = ContentIds.Circus,               MaxCount = 2 },
+                new() { Sid = ContentIds.InfernalCirque,      MaxCount = 2 },
+                new() { Sid = ContentIds.FlatteringMirror,    MaxCount = 2 },
+                new() { Sid = ContentIds.FickleShrine,        MaxCount = 1 },
+                new() { Sid = ContentIds.PointOfBalance,     MaxCount = 3 },
 
                 // ── Special / loot ───────────────────────────────────────────────
-                new() { Sid = "pandora_box",          MaxCount = 4 },
+                new() { Sid = ContentIds.PandoraBox,          MaxCount = 4 },
 
                 // ── Map-feature objects (typically 0 = disabled, 99 = unlimited;
                 //    we cap at a sensible value so they can occasionally appear) ──
-                new() { Sid = "ritual_pyre",          MaxCount = 3 },
-                new() { Sid = "boreal_call",          MaxCount = 3 },
-                new() { Sid = "jousting_range",       MaxCount = 1 },
-                new() { Sid = "unforgotten_grave",    MaxCount = 1 },
-                new() { Sid = "petrified_memorial",   MaxCount = 1 },
-                new() { Sid = "the_gorge",            MaxCount = 1 },
+                new() { Sid = ContentIds.RitualPyre,          MaxCount = 3 },
+                new() { Sid = ContentIds.BorealCall,          MaxCount = 3 },
+                new() { Sid = ContentIds.JoustingRange,       MaxCount = 1 },
+                new() { Sid = ContentIds.UnforgottenGrave,    MaxCount = 1 },
+                new() { Sid = ContentIds.PetrifiedMemorial,   MaxCount = 1 },
+                new() { Sid = ContentIds.TheGorge,            MaxCount = 1 },
             };
 
             var limits = new List<ContentCountLimit>();


### PR DESCRIPTION
Some idea to start some abstraction of management of common content within zones.
This gives us some overview on common patterns and rules used across templates. I assume the original values were taken from existing presets as a baseline? There is some weird stuff going around (what does it mean to have weight == 0 in the rule?), but left everything as-is for now.

I think in the end would be cool to have full control over zone contents - ex. like in Homm3 8xm8 was based around dragon fly hives. But let's do it brick by brick, especially if people are forking stuff and conflicts on basically one-file repo are tough with bigger changes.

Might look a bit weird with IncludeLists still being hardcoded, but packing them to separate classes seemed pointless ATM (as we need to know anyway their name). For sure this can be expanded upon.