### PR TITLE
Feature: Bonuses & Bans tab — for items, spells, and value overrides

### DIFF
--- a/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
+++ b/Olden Era - Template Editor.Tests/TemplateGeneratorTests.cs
@@ -910,6 +910,193 @@ public class TemplateGeneratorTests
         });
     }
 
+    // ── Bonuses ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_WithNoBonusesLeavesGameRulesBonusesNull()
+    {
+        var settings = new GeneratorSettings { Bonuses = [] };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.Null(template.GameRules?.Bonuses);
+    }
+
+    [Fact]
+    public void Generate_TownPortalFreeBonusExpandsToTwoRawBonuses()
+    {
+        var settings = new GeneratorSettings
+        {
+            Bonuses =
+            [
+                new BonusEntry { PresetType = BonusPresetType.TownPortalFree, ReceiverFilter = "start_hero" }
+            ]
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.NotNull(template.GameRules?.Bonuses);
+        var bonuses = template.GameRules!.Bonuses!;
+        Assert.Equal(2, bonuses.Count);
+        Assert.Contains(bonuses, b => b.Sid == "add_bonus_hero_spell" && (b.Parameters?.Contains("neutral_magic_town_portal") ?? false));
+        Assert.Contains(bonuses, b => b.Sid == "add_bonus_hero_stat"  && (b.Parameters?.Contains("neutral_magic_town_portal") ?? false));
+    }
+
+    [Fact]
+    public void Generate_StartingItemBonusExpandsToOneRawBonus()
+    {
+        var settings = new GeneratorSettings
+        {
+            Bonuses =
+            [
+                new BonusEntry { PresetType = BonusPresetType.StartingItem, ReceiverFilter = "all_heroes", Param = "amulet_of_health" }
+            ]
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.NotNull(template.GameRules?.Bonuses);
+        var bonuses = template.GameRules!.Bonuses!;
+        Bonus bonus = Assert.Single(bonuses);
+        Assert.Equal("add_bonus_hero_item", bonus.Sid);
+        Assert.Equal("all_heroes", bonus.ReceiverFilter);
+        Assert.Contains("amulet_of_health", bonus.Parameters ?? []);
+    }
+
+    [Fact]
+    public void Generate_MultipleBonusEntriesAreAllExpanded()
+    {
+        var settings = new GeneratorSettings
+        {
+            Bonuses =
+            [
+                new BonusEntry { PresetType = BonusPresetType.StartingGold,    Param = "2000" },
+                new BonusEntry { PresetType = BonusPresetType.MovementBonus,   Param = "200"  },
+            ]
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.NotNull(template.GameRules?.Bonuses);
+        var bonuses = template.GameRules!.Bonuses!;
+        Assert.Equal(2, bonuses.Count);
+        Assert.Contains(bonuses, b => b.Sid == "add_bonus_res"      && (b.Parameters?.Contains("gold") ?? false));
+        Assert.Contains(bonuses, b => b.Sid == "add_bonus_hero_stat" && (b.Parameters?.Contains("movementBonus") ?? false));
+    }
+
+    // ── Value overrides ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_WithEmptyValueOverridesTextLeavesOverridesNull()
+    {
+        var settings = new GeneratorSettings { ValueOverridesText = "" };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.Null(template.ValueOverrides);
+    }
+
+    [Fact]
+    public void Generate_ParsesValidValueOverrideLines()
+    {
+        var settings = new GeneratorSettings
+        {
+            ValueOverridesText = "dragon_utopia=10000\narena=5000"
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.NotNull(template.ValueOverrides);
+        var overrides = template.ValueOverrides!;
+        Assert.Equal(2, overrides.Count);
+        Assert.Contains(overrides, v => v.Sid == "dragon_utopia" && v.GuardValue == 10000 && v.Variant == -1);
+        Assert.Contains(overrides, v => v.Sid == "arena"         && v.GuardValue == 5000  && v.Variant == -1);
+    }
+
+    [Fact]
+    public void Generate_SkipsMalformedAndBlankValueOverrideLines()
+    {
+        var settings = new GeneratorSettings
+        {
+            ValueOverridesText = "arena=5000\n\nbadline\n=1000\nalchemy_lab=3000"
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.NotNull(template.ValueOverrides);
+        var overrides = template.ValueOverrides!;
+        Assert.Equal(2, overrides.Count);
+        Assert.Contains(overrides, v => v.Sid == "arena");
+        Assert.Contains(overrides, v => v.Sid == "alchemy_lab");
+    }
+
+    // ── Global bans ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_WithNoBansLeavesGlobalBansNull()
+    {
+        var settings = new GeneratorSettings { BannedItems = "", BannedMagics = "" };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.Null(template.GlobalBans);
+    }
+
+    [Fact]
+    public void Generate_BannedItemsAreWrittenToGlobalBansItems()
+    {
+        var settings = new GeneratorSettings
+        {
+            BannedItems  = "amulet_of_health\nring_of_life",
+            BannedMagics = ""
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.NotNull(template.GlobalBans);
+        var bans = template.GlobalBans!;
+        Assert.NotNull(bans.Items);
+        Assert.Contains("amulet_of_health", bans.Items);
+        Assert.Contains("ring_of_life",     bans.Items);
+        Assert.Null(bans.Magics);
+    }
+
+    [Fact]
+    public void Generate_BannedMagicsAreWrittenToGlobalBansMagics()
+    {
+        var settings = new GeneratorSettings
+        {
+            BannedItems  = "",
+            BannedMagics = "neutral_magic_town_portal\nneutral_magic_dimension_door"
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.NotNull(template.GlobalBans);
+        var bans = template.GlobalBans!;
+        Assert.Null(bans.Items);
+        Assert.NotNull(bans.Magics);
+        Assert.Contains("neutral_magic_town_portal",    bans.Magics);
+        Assert.Contains("neutral_magic_dimension_door", bans.Magics);
+    }
+
+    [Fact]
+    public void Generate_ItemsAndMagicsBannedTogetherWritesBothLists()
+    {
+        var settings = new GeneratorSettings
+        {
+            BannedItems  = "amulet_of_health",
+            BannedMagics = "neutral_magic_town_portal"
+        };
+
+        RmgTemplate template = TemplateGenerator.Generate(settings);
+
+        Assert.NotNull(template.GlobalBans);
+        var bans = template.GlobalBans!;
+        Assert.NotNull(bans.Items);
+        Assert.NotNull(bans.Magics);
+    }
+
     private static List<MainObject> Cities(int count) =>
         Enumerable.Range(0, count).Select(_ => new MainObject { Type = "City" }).ToList();
 

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml
@@ -99,7 +99,9 @@
                     <TextBlock Text="Artifact ID" Foreground="#9A8A6A" FontSize="11" Margin="0,0,0,3"/>
                     <DockPanel>
                         <Button DockPanel.Dock="Right" Content="Pick…" Width="64"
-                                Height="26" Margin="6,0,0,0" Click="BtnPickItem_Click"/>
+                                Height="26" Margin="6,0,0,0" Click="BtnPickItem_Click"
+                                Background="#1E1A10" BorderBrush="#7A6A48"
+                                Foreground="#C8B87A" FontSize="12" Cursor="Hand"/>
                         <TextBox x:Name="TxtItem" Height="26"
                                  Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28"
                                  CaretBrush="#C9A84C" Padding="6,0"

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml
@@ -66,6 +66,9 @@
                                  CaretBrush="#C9A84C" Padding="6,0"
                                  FontFamily="Consolas" FontSize="11"/>
                     </DockPanel>
+                    <CheckBox x:Name="ChkMakeFree" Margin="0,8,0,0"
+                              Content="Make this spell free (zero cast cost)"
+                              Foreground="#E8D5A3"/>
                 </StackPanel>
 
                 <!-- Unit Multiplier -->

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml
@@ -27,7 +27,6 @@
                 <ComboBox x:Name="CmbType" Height="28"
                           SelectionChanged="CmbType_Changed"
                           Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28">
-                    <ComboBoxItem Tag="0" Content="Town Portal (free)"/>
                     <ComboBoxItem Tag="1" Content="Spell"/>
                     <ComboBoxItem Tag="2" Content="Unit Multiplier"/>
                     <ComboBoxItem Tag="3" Content="Movement Bonus"/>
@@ -48,13 +47,8 @@
 
                 <!-- ── Dynamic parameter panels ── -->
 
-                <!-- Town Portal: info label only -->
-                <TextBlock x:Name="PnlTownPortal" Margin="0,10,0,0"
-                           Text="Grants Town Portal to the starting hero and makes it free (zero cost)."
-                           TextWrapping="Wrap" Foreground="#9A8A6A" FontStyle="Italic"/>
-
                 <!-- Spell -->
-                <StackPanel x:Name="PnlSpell" Visibility="Collapsed" Margin="0,8,0,0">
+                <StackPanel x:Name="PnlSpell" Margin="0,8,0,0">
                     <TextBlock Text="Spell" Foreground="#9A8A6A" FontSize="11" Margin="0,0,0,3"/>
                     <DockPanel>
                         <Button DockPanel.Dock="Right" Content="Pick…" Width="64"

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml
@@ -1,0 +1,122 @@
+<Window x:Class="Olden_Era___Template_Editor.BonusPickerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Add Bonus" Width="420" Height="370"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize" MinWidth="350" MinHeight="280"
+        Background="#221E15" Foreground="#E8D5A3"
+        FontFamily="Segoe UI" FontSize="13">
+
+    <DockPanel Margin="14">
+
+        <!-- Buttons (bottom) -->
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
+                    HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button x:Name="BtnAdd" Content="Add" Width="90" Height="28"
+                    Margin="0,0,8,0" IsDefault="True" Click="BtnAdd_Click"/>
+            <Button Content="Cancel" Width="80" Height="28"
+                    IsCancel="True" Click="BtnCancel_Click"/>
+        </StackPanel>
+
+        <!-- Main form -->
+        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel>
+
+                <!-- Bonus type -->
+                <TextBlock Text="Bonus type" Foreground="#9A8A6A" FontSize="11" Margin="0,0,0,3"/>
+                <ComboBox x:Name="CmbType" Height="28"
+                          SelectionChanged="CmbType_Changed"
+                          Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28">
+                    <ComboBoxItem Tag="0" Content="Town Portal (free)"/>
+                    <ComboBoxItem Tag="1" Content="Spell"/>
+                    <ComboBoxItem Tag="2" Content="Unit Multiplier"/>
+                    <ComboBoxItem Tag="3" Content="Movement Bonus"/>
+                    <ComboBoxItem Tag="4" Content="Starting Item"/>
+                    <ComboBoxItem Tag="5" Content="Starting Gold"/>
+                    <ComboBoxItem Tag="6" Content="Starting Gems"/>
+                    <ComboBoxItem Tag="7" Content="Starting Crystals"/>
+                    <ComboBoxItem Tag="8" Content="Starting Mercury"/>
+                </ComboBox>
+
+                <!-- Receiver -->
+                <TextBlock Text="Applies to" Foreground="#9A8A6A" FontSize="11" Margin="0,8,0,3"/>
+                <ComboBox x:Name="CmbReceiver" Height="28"
+                          Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28">
+                    <ComboBoxItem Tag="start_hero" Content="Start hero"/>
+                    <ComboBoxItem Tag="all_heroes" Content="All heroes"/>
+                </ComboBox>
+
+                <!-- ── Dynamic parameter panels ── -->
+
+                <!-- Town Portal: info label only -->
+                <TextBlock x:Name="PnlTownPortal" Margin="0,10,0,0"
+                           Text="Grants Town Portal to the starting hero and makes it free (zero cost)."
+                           TextWrapping="Wrap" Foreground="#9A8A6A" FontStyle="Italic"/>
+
+                <!-- Spell -->
+                <StackPanel x:Name="PnlSpell" Visibility="Collapsed" Margin="0,8,0,0">
+                    <TextBlock Text="Spell" Foreground="#9A8A6A" FontSize="11" Margin="0,0,0,3"/>
+                    <ComboBox x:Name="CmbSpell" Height="28"
+                              SelectionChanged="CmbSpell_Changed"
+                              Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28">
+                        <ComboBoxItem Tag="neutral_magic_town_portal"      Content="Town Portal"/>
+                        <ComboBoxItem Tag="neutral_magic_dimension_door"   Content="Dimension Door"/>
+                        <ComboBoxItem Tag="neutral_magic_shadow_form"      Content="Shadow Form"/>
+                        <ComboBoxItem Tag="neutral_magic_light_gate"       Content="Light Gate"/>
+                        <ComboBoxItem Tag="neutral_magic_pocket_dimension" Content="Pocket Dimension"/>
+                        <ComboBoxItem Tag="" Content="Custom…"/>
+                    </ComboBox>
+                    <TextBox x:Name="TxtSpellCustom" Margin="0,4,0,0" Height="26"
+                             Visibility="Collapsed"
+                             Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28"
+                             CaretBrush="#C9A84C" Padding="6,0"
+                             FontFamily="Consolas" FontSize="11"/>
+                    <CheckBox x:Name="ChkMakeFree" Margin="0,8,0,0"
+                              Content="Make this spell free (zero cast cost)"
+                              Foreground="#E8D5A3"/>
+                </StackPanel>
+
+                <!-- Unit Multiplier -->
+                <StackPanel x:Name="PnlMultiplier" Visibility="Collapsed" Margin="0,8,0,0">
+                    <TextBlock Text="Multiplier  (e.g. 2 = double starting army)"
+                               Foreground="#9A8A6A" FontSize="11" Margin="0,0,0,3"/>
+                    <TextBox x:Name="TxtMultiplier" Height="26" Text="2"
+                             Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28"
+                             CaretBrush="#C9A84C" Padding="6,0"/>
+                </StackPanel>
+
+                <!-- Movement Bonus -->
+                <StackPanel x:Name="PnlMovement" Visibility="Collapsed" Margin="0,8,0,0">
+                    <TextBlock Text="Bonus movement tiles  (0 = game default)"
+                               Foreground="#9A8A6A" FontSize="11" Margin="0,0,0,3"/>
+                    <TextBox x:Name="TxtMovement" Height="26" Text="0"
+                             Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28"
+                             CaretBrush="#C9A84C" Padding="6,0"/>
+                </StackPanel>
+
+                <!-- Starting Item -->
+                <StackPanel x:Name="PnlItem" Visibility="Collapsed" Margin="0,8,0,0">
+                    <TextBlock Text="Artifact ID" Foreground="#9A8A6A" FontSize="11" Margin="0,0,0,3"/>
+                    <DockPanel>
+                        <Button DockPanel.Dock="Right" Content="Pick…" Width="64"
+                                Height="26" Margin="6,0,0,0" Click="BtnPickItem_Click"/>
+                        <TextBox x:Name="TxtItem" Height="26"
+                                 Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28"
+                                 CaretBrush="#C9A84C" Padding="6,0"
+                                 FontFamily="Consolas" FontSize="11"/>
+                    </DockPanel>
+                </StackPanel>
+
+                <!-- Resources (Gold / Gems / Crystals / Mercury) -->
+                <StackPanel x:Name="PnlResources" Visibility="Collapsed" Margin="0,8,0,0">
+                    <TextBlock x:Name="LblResourceAmount" Text="Amount"
+                               Foreground="#9A8A6A" FontSize="11" Margin="0,0,0,3"/>
+                    <TextBox x:Name="TxtResourceAmount" Height="26" Text="10000"
+                             Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28"
+                             CaretBrush="#C9A84C" Padding="6,0"/>
+                </StackPanel>
+
+            </StackPanel>
+        </ScrollViewer>
+    </DockPanel>
+</Window>

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml
@@ -56,24 +56,16 @@
                 <!-- Spell -->
                 <StackPanel x:Name="PnlSpell" Visibility="Collapsed" Margin="0,8,0,0">
                     <TextBlock Text="Spell" Foreground="#9A8A6A" FontSize="11" Margin="0,0,0,3"/>
-                    <ComboBox x:Name="CmbSpell" Height="28"
-                              SelectionChanged="CmbSpell_Changed"
-                              Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28">
-                        <ComboBoxItem Tag="neutral_magic_town_portal"      Content="Town Portal"/>
-                        <ComboBoxItem Tag="neutral_magic_dimension_door"   Content="Dimension Door"/>
-                        <ComboBoxItem Tag="neutral_magic_shadow_form"      Content="Shadow Form"/>
-                        <ComboBoxItem Tag="neutral_magic_light_gate"       Content="Light Gate"/>
-                        <ComboBoxItem Tag="neutral_magic_pocket_dimension" Content="Pocket Dimension"/>
-                        <ComboBoxItem Tag="" Content="Custom…"/>
-                    </ComboBox>
-                    <TextBox x:Name="TxtSpellCustom" Margin="0,4,0,0" Height="26"
-                             Visibility="Collapsed"
-                             Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28"
-                             CaretBrush="#C9A84C" Padding="6,0"
-                             FontFamily="Consolas" FontSize="11"/>
-                    <CheckBox x:Name="ChkMakeFree" Margin="0,8,0,0"
-                              Content="Make this spell free (zero cast cost)"
-                              Foreground="#E8D5A3"/>
+                    <DockPanel>
+                        <Button DockPanel.Dock="Right" Content="Pick…" Width="64"
+                                Height="26" Margin="6,0,0,0" Click="BtnPickSpell_Click"
+                                Background="#1E1A10" BorderBrush="#7A6A48"
+                                Foreground="#C8B87A" FontSize="12" Cursor="Hand"/>
+                        <TextBox x:Name="TxtSpell" Height="26" IsReadOnly="True"
+                                 Background="#2C2619" Foreground="#E8D5A3" BorderBrush="#5A4A28"
+                                 CaretBrush="#C9A84C" Padding="6,0"
+                                 FontFamily="Consolas" FontSize="11"/>
+                    </DockPanel>
                 </StackPanel>
 
                 <!-- Unit Multiplier -->

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
@@ -48,7 +48,6 @@ namespace Olden_Era___Template_Editor
             if (!IsInitialized) return;
             var type = SelectedType;
 
-            PnlTownPortal.Visibility = type == BonusPresetType.TownPortalFree    ? Visibility.Visible : Visibility.Collapsed;
             PnlSpell.Visibility      = type == BonusPresetType.Spell              ? Visibility.Visible : Visibility.Collapsed;
             PnlMultiplier.Visibility = type == BonusPresetType.UnitMultiplier     ? Visibility.Visible : Visibility.Collapsed;
             PnlMovement.Visibility   = type == BonusPresetType.MovementBonus      ? Visibility.Visible : Visibility.Collapsed;
@@ -134,9 +133,6 @@ namespace Olden_Era___Template_Editor
 
             switch (type)
             {
-                case BonusPresetType.TownPortalFree:
-                    break;
-
                 case BonusPresetType.Spell:
                     param = TxtSpell.Text.Trim();
                     if (string.IsNullOrEmpty(param))

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
@@ -1,4 +1,5 @@
 using OldenEraTemplateEditor.Models;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -7,7 +8,8 @@ namespace Olden_Era___Template_Editor
 {
     public partial class BonusPickerWindow : Window
     {
-        public BonusEntry? Result { get; private set; }
+        public BonusEntry?       Result  { get; private set; }
+        public List<BonusEntry>  Results { get; private set; } = [];
 
         public BonusPickerWindow()
         {
@@ -68,8 +70,26 @@ namespace Olden_Era___Template_Editor
             var entries = KnownValues.BannableItems
                 .Select(b => new BanEntry { Id = b.Id, DisplayName = b.DisplayName, Category = b.Category });
             var picker = new ItemPickerWindow(entries, [], "Pick Starting Item") { Owner = this };
-            if (picker.ShowDialog() == true && picker.SelectedId is { } id)
-                TxtItem.Text = id;
+            if (picker.ShowDialog() != true) return;
+
+            if (picker.SelectedIds.Count > 1)
+            {
+                // Multi-selection: build one StartingItem bonus per artifact and close immediately
+                var receiver = SelectedReceiver;
+                Results = picker.SelectedIds
+                    .Select(id => new BonusEntry
+                    {
+                        PresetType     = BonusPresetType.StartingItem,
+                        ReceiverFilter = receiver,
+                        Param          = id,
+                    })
+                    .ToList();
+                DialogResult = true;
+            }
+            else if (picker.SelectedIds.Count == 1)
+            {
+                TxtItem.Text = picker.SelectedIds[0];
+            }
         }
 
         private void BtnAdd_Click(object sender, RoutedEventArgs e)
@@ -127,6 +147,7 @@ namespace Olden_Era___Template_Editor
                 Param          = param,
                 Param2         = param2,
             };
+            Results      = [Result];
             DialogResult = true;
         }
 

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
@@ -13,18 +13,23 @@ namespace Olden_Era___Template_Editor
 
         private readonly HashSet<string> _existingKeys;
         private readonly HashSet<string> _existingItemIds;
+        private readonly HashSet<string> _existingSpellIds;
+        private bool                     _spellMakeFree;
 
         public BonusPickerWindow(IEnumerable<BonusEntry>? existingBonuses = null)
         {
             InitializeComponent();
             CmbType.SelectedIndex     = 0;
             CmbReceiver.SelectedIndex = 0;
-            CmbSpell.SelectedIndex    = 0;
 
             var existing = existingBonuses?.ToList() ?? [];
-            _existingKeys    = existing.Select(b => b.ToString()).ToHashSet();
-            _existingItemIds = existing
+            _existingKeys     = existing.Select(b => b.ToString()).ToHashSet();
+            _existingItemIds  = existing
                 .Where(b => b.PresetType == BonusPresetType.StartingItem)
+                .Select(b => b.Param)
+                .ToHashSet();
+            _existingSpellIds = existing
+                .Where(b => b.PresetType == BonusPresetType.Spell)
                 .Select(b => b.Param)
                 .ToHashSet();
         }
@@ -68,11 +73,30 @@ namespace Olden_Era___Template_Editor
             }
         }
 
-        private void CmbSpell_Changed(object sender, SelectionChangedEventArgs e)
+        private void BtnPickSpell_Click(object sender, RoutedEventArgs e)
         {
-            if (!IsInitialized) return;
-            var tag = (string)((ComboBoxItem)CmbSpell.SelectedItem).Tag;
-            TxtSpellCustom.Visibility = string.IsNullOrEmpty(tag) ? Visibility.Visible : Visibility.Collapsed;
+            var picker = new SpellPickerWindow(_existingSpellIds) { Owner = this };
+            if (picker.ShowDialog() != true) return;
+
+            if (picker.SelectedIds.Count > 1)
+            {
+                var receiver = SelectedReceiver;
+                Results = picker.SelectedIds
+                    .Select(id => new BonusEntry
+                    {
+                        PresetType     = BonusPresetType.Spell,
+                        ReceiverFilter = receiver,
+                        Param          = id,
+                        Param2         = picker.MakeFree ? "1" : "0",
+                    })
+                    .ToList();
+                DialogResult = true;
+            }
+            else if (picker.SelectedIds.Count == 1)
+            {
+                TxtSpell.Text  = picker.SelectedIds[0];
+                _spellMakeFree = picker.MakeFree;
+            }
         }
 
         private void BtnPickItem_Click(object sender, RoutedEventArgs e)
@@ -115,14 +139,13 @@ namespace Olden_Era___Template_Editor
                     break;
 
                 case BonusPresetType.Spell:
-                    var spellTag = (string)((ComboBoxItem)CmbSpell.SelectedItem).Tag;
-                    param = string.IsNullOrEmpty(spellTag) ? TxtSpellCustom.Text.Trim() : spellTag;
+                    param = TxtSpell.Text.Trim();
                     if (string.IsNullOrEmpty(param))
                     {
-                        MessageBox.Show("Enter a spell ID.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        MessageBox.Show("Pick a spell first.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
                         return;
                     }
-                    param2 = ChkMakeFree.IsChecked == true ? "1" : "0";
+                    param2 = _spellMakeFree ? "1" : "0";
                     break;
 
                 case BonusPresetType.UnitMultiplier:

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
@@ -14,7 +14,6 @@ namespace Olden_Era___Template_Editor
         private readonly HashSet<string> _existingKeys;
         private readonly HashSet<string> _existingItemIds;
         private readonly HashSet<string> _existingSpellIds;
-        private bool                     _spellMakeFree;
 
         public BonusPickerWindow(IEnumerable<BonusEntry>? existingBonuses = null)
         {
@@ -94,8 +93,8 @@ namespace Olden_Era___Template_Editor
             }
             else if (picker.SelectedIds.Count == 1)
             {
-                TxtSpell.Text  = picker.SelectedIds[0];
-                _spellMakeFree = picker.MakeFree;
+                TxtSpell.Text         = picker.SelectedIds[0];
+                ChkMakeFree.IsChecked = picker.MakeFree;
             }
         }
 
@@ -145,7 +144,7 @@ namespace Olden_Era___Template_Editor
                         MessageBox.Show("Pick a spell first.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
                         return;
                     }
-                    param2 = _spellMakeFree ? "1" : "0";
+                    param2 = ChkMakeFree.IsChecked == true ? "1" : "0";
                     break;
 
                 case BonusPresetType.UnitMultiplier:

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
@@ -11,12 +11,22 @@ namespace Olden_Era___Template_Editor
         public BonusEntry?       Result  { get; private set; }
         public List<BonusEntry>  Results { get; private set; } = [];
 
-        public BonusPickerWindow()
+        private readonly HashSet<string> _existingKeys;
+        private readonly HashSet<string> _existingItemIds;
+
+        public BonusPickerWindow(IEnumerable<BonusEntry>? existingBonuses = null)
         {
             InitializeComponent();
             CmbType.SelectedIndex     = 0;
             CmbReceiver.SelectedIndex = 0;
             CmbSpell.SelectedIndex    = 0;
+
+            var existing = existingBonuses?.ToList() ?? [];
+            _existingKeys    = existing.Select(b => b.ToString()).ToHashSet();
+            _existingItemIds = existing
+                .Where(b => b.PresetType == BonusPresetType.StartingItem)
+                .Select(b => b.Param)
+                .ToHashSet();
         }
 
         // ── Helpers ──────────────────────────────────────────────────────────────
@@ -69,7 +79,7 @@ namespace Olden_Era___Template_Editor
         {
             var entries = KnownValues.BannableItems
                 .Select(b => new BanEntry { Id = b.Id, DisplayName = b.DisplayName, Category = b.Category });
-            var picker = new ItemPickerWindow(entries, [], "Pick Starting Item") { Owner = this };
+            var picker = new ItemPickerWindow(entries, _existingItemIds, "Pick Starting Item") { Owner = this };
             if (picker.ShowDialog() != true) return;
 
             if (picker.SelectedIds.Count > 1)
@@ -140,13 +150,21 @@ namespace Olden_Era___Template_Editor
                     break;
             }
 
-            Result = new BonusEntry
+            var candidate = new BonusEntry
             {
                 PresetType     = type,
                 ReceiverFilter = receiver,
                 Param          = param,
                 Param2         = param2,
             };
+
+            if (_existingKeys.Contains(candidate.ToString()))
+            {
+                MessageBox.Show("This bonus has already been added.", "Duplicate", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            Result       = candidate;
             Results      = [Result];
             DialogResult = true;
         }

--- a/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/BonusPickerWindow.xaml.cs
@@ -1,0 +1,136 @@
+using OldenEraTemplateEditor.Models;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Olden_Era___Template_Editor
+{
+    public partial class BonusPickerWindow : Window
+    {
+        public BonusEntry? Result { get; private set; }
+
+        public BonusPickerWindow()
+        {
+            InitializeComponent();
+            CmbType.SelectedIndex     = 0;
+            CmbReceiver.SelectedIndex = 0;
+            CmbSpell.SelectedIndex    = 0;
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────────────
+
+        private BonusPresetType SelectedType =>
+            (BonusPresetType)int.Parse((string)((ComboBoxItem)CmbType.SelectedItem).Tag);
+
+        private string SelectedReceiver =>
+            (string)((ComboBoxItem)CmbReceiver.SelectedItem).Tag;
+
+        // ── Event handlers ────────────────────────────────────────────────────────
+
+        private void CmbType_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (!IsInitialized) return;
+            var type = SelectedType;
+
+            PnlTownPortal.Visibility = type == BonusPresetType.TownPortalFree    ? Visibility.Visible : Visibility.Collapsed;
+            PnlSpell.Visibility      = type == BonusPresetType.Spell              ? Visibility.Visible : Visibility.Collapsed;
+            PnlMultiplier.Visibility = type == BonusPresetType.UnitMultiplier     ? Visibility.Visible : Visibility.Collapsed;
+            PnlMovement.Visibility   = type == BonusPresetType.MovementBonus      ? Visibility.Visible : Visibility.Collapsed;
+            PnlItem.Visibility       = type == BonusPresetType.StartingItem       ? Visibility.Visible : Visibility.Collapsed;
+            PnlResources.Visibility  = type is BonusPresetType.StartingGold
+                                           or BonusPresetType.StartingGems
+                                           or BonusPresetType.StartingCrystals
+                                           or BonusPresetType.StartingMercury
+                                       ? Visibility.Visible : Visibility.Collapsed;
+
+            if (PnlResources.Visibility == Visibility.Visible)
+            {
+                (LblResourceAmount.Text, TxtResourceAmount.Text) = type switch
+                {
+                    BonusPresetType.StartingGold     => ("Gold amount",     "10000"),
+                    BonusPresetType.StartingGems     => ("Gems amount",     "15"),
+                    BonusPresetType.StartingCrystals => ("Crystals amount", "15"),
+                    BonusPresetType.StartingMercury  => ("Mercury amount",  "15"),
+                    _                                => ("Amount",          "10000"),
+                };
+            }
+        }
+
+        private void CmbSpell_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (!IsInitialized) return;
+            var tag = (string)((ComboBoxItem)CmbSpell.SelectedItem).Tag;
+            TxtSpellCustom.Visibility = string.IsNullOrEmpty(tag) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void BtnPickItem_Click(object sender, RoutedEventArgs e)
+        {
+            var entries = KnownValues.BannableItems
+                .Select(b => new BanEntry { Id = b.Id, DisplayName = b.DisplayName, Category = b.Category });
+            var picker = new ItemPickerWindow(entries, [], "Pick Starting Item") { Owner = this };
+            if (picker.ShowDialog() == true && picker.SelectedId is { } id)
+                TxtItem.Text = id;
+        }
+
+        private void BtnAdd_Click(object sender, RoutedEventArgs e)
+        {
+            var type     = SelectedType;
+            var receiver = SelectedReceiver;
+            string param  = "";
+            string param2 = "0";
+
+            switch (type)
+            {
+                case BonusPresetType.TownPortalFree:
+                    break;
+
+                case BonusPresetType.Spell:
+                    var spellTag = (string)((ComboBoxItem)CmbSpell.SelectedItem).Tag;
+                    param = string.IsNullOrEmpty(spellTag) ? TxtSpellCustom.Text.Trim() : spellTag;
+                    if (string.IsNullOrEmpty(param))
+                    {
+                        MessageBox.Show("Enter a spell ID.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        return;
+                    }
+                    param2 = ChkMakeFree.IsChecked == true ? "1" : "0";
+                    break;
+
+                case BonusPresetType.UnitMultiplier:
+                    param = TxtMultiplier.Text.Trim();
+                    if (string.IsNullOrEmpty(param)) param = "2";
+                    break;
+
+                case BonusPresetType.MovementBonus:
+                    param = TxtMovement.Text.Trim();
+                    if (string.IsNullOrEmpty(param)) param = "0";
+                    break;
+
+                case BonusPresetType.StartingItem:
+                    param = TxtItem.Text.Trim();
+                    if (string.IsNullOrEmpty(param))
+                    {
+                        MessageBox.Show("Enter or pick an artifact ID.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        return;
+                    }
+                    break;
+
+                default: // StartingGold, StartingGems, StartingCrystals, StartingMercury
+                    param = TxtResourceAmount.Text.Trim();
+                    if (string.IsNullOrEmpty(param)) param = "0";
+                    break;
+            }
+
+            Result = new BonusEntry
+            {
+                PresetType     = type,
+                ReceiverFilter = receiver,
+                Param          = param,
+                Param2         = param2,
+            };
+            DialogResult = true;
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e)
+            => DialogResult = false;
+    }
+}

--- a/Olden Era - Template Editor/GameData/spells.json
+++ b/Olden Era - Template Editor/GameData/spells.json
@@ -1,0 +1,620 @@
+[
+  {
+    "id": "day_2_magic_sharp_edge",
+    "name": "Blessing",
+    "school": "day",
+    "tier": 1
+  },
+  {
+    "id": "day_3_magic_haste",
+    "name": "Haste",
+    "school": "day",
+    "tier": 1
+  },
+  {
+    "id": "day_1_magic_healing_water",
+    "name": "Healing Water",
+    "school": "day",
+    "tier": 1
+  },
+  {
+    "id": "day_5_magic_shorten_shadow",
+    "name": "Shorten Shadow",
+    "school": "day",
+    "tier": 1
+  },
+  {
+    "id": "day_4_magic_favorable_wind",
+    "name": "Favorable Wind",
+    "school": "day",
+    "tier": 2
+  },
+  {
+    "id": "day_17_magic_clear_view",
+    "name": "From a Bird’s Eye",
+    "school": "day",
+    "tier": 2
+  },
+  {
+    "id": "day_7_magic_inner_light",
+    "name": "Inner Light",
+    "school": "day",
+    "tier": 2
+  },
+  {
+    "id": "day_6_magic_cleansing_ray",
+    "name": "Weakening Ray",
+    "school": "day",
+    "tier": 2
+  },
+  {
+    "id": "day_9_magic_arinas_hymn",
+    "name": "Arina’s Touch",
+    "school": "day",
+    "tier": 3
+  },
+  {
+    "id": "day_11_magic_masterful_parry",
+    "name": "Riposte",
+    "school": "day",
+    "tier": 3
+  },
+  {
+    "id": "day_10_magic_second_song",
+    "name": "Song of Power",
+    "school": "day",
+    "tier": 3
+  },
+  {
+    "id": "day_8_magic_taunt",
+    "name": "Taunt",
+    "school": "day",
+    "tier": 3
+  },
+  {
+    "id": "day_18_magic_farsight",
+    "name": "Clear Fog",
+    "school": "day",
+    "tier": 4
+  },
+  {
+    "id": "day_13_magic_holy_arms",
+    "name": "Heavenly Blades",
+    "school": "day",
+    "tier": 4
+  },
+  {
+    "id": "day_12_magic_radiant_armor",
+    "name": "Radiant Armor",
+    "school": "day",
+    "tier": 4
+  },
+  {
+    "id": "day_14_magic_vengeance",
+    "name": "Vengeance",
+    "school": "day",
+    "tier": 4
+  },
+  {
+    "id": "day_16_magic_arinas_chosen",
+    "name": "Arina’s Chosen",
+    "school": "day",
+    "tier": 5
+  },
+  {
+    "id": "day_15_magic_judgement",
+    "name": "Judgement",
+    "school": "day",
+    "tier": 5
+  },
+  {
+    "id": "neutral_1_magic_back_to_garrison",
+    "name": "Back to Foothold!",
+    "school": "neutral",
+    "tier": 1
+  },
+  {
+    "id": "neutral_1_magic_back_to_city",
+    "name": "Back to Town!",
+    "school": "neutral",
+    "tier": 1
+  },
+  {
+    "id": "bonus_magic_kill_summon",
+    "name": "Dispel Summon",
+    "school": "neutral",
+    "tier": 1
+  },
+  {
+    "id": "night_bonus_magic_1_magic",
+    "name": "Dusk Dampening",
+    "school": "neutral",
+    "tier": 1
+  },
+  {
+    "id": "bonus_magic_pure_bolt",
+    "name": "Magic Arrow",
+    "school": "neutral",
+    "tier": 1
+  },
+  {
+    "id": "neutral_1_magic_mana_restore",
+    "name": "Mana Rite",
+    "school": "neutral",
+    "tier": 1
+  },
+  {
+    "id": "neutral_1_magic_mana_transfer",
+    "name": "Mana Transfusion",
+    "school": "neutral",
+    "tier": 1
+  },
+  {
+    "id": "change_use_necromancy",
+    "name": "Necromancer Will",
+    "school": "neutral",
+    "tier": 1
+  },
+  {
+    "id": "neutral_1_magic_units_replace",
+    "name": "Relocation",
+    "school": "neutral",
+    "tier": 1
+  },
+  {
+    "id": "primal_bonus_magic_1_magic",
+    "name": "Spell Eruption",
+    "school": "neutral",
+    "tier": 1
+  },
+  {
+    "id": "neutral_magic_pocket_dimension",
+    "name": "Pocket Dimension",
+    "school": "neutral",
+    "tier": 2
+  },
+  {
+    "id": "neutral_magic_second_sight",
+    "name": "Second Wind",
+    "school": "neutral",
+    "tier": 2
+  },
+  {
+    "id": "bonus_magic_astral_summon_1",
+    "name": "bonus_magic_astral_summon_1",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_2",
+    "name": "bonus_magic_astral_summon_2",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_3",
+    "name": "bonus_magic_astral_summon_3",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_4",
+    "name": "bonus_magic_astral_summon_4",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_5",
+    "name": "bonus_magic_astral_summon_5",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_nature_1",
+    "name": "bonus_magic_astral_summon_nature_1",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_nature_2",
+    "name": "bonus_magic_astral_summon_nature_2",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_nature_3",
+    "name": "bonus_magic_astral_summon_nature_3",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_nature_4",
+    "name": "bonus_magic_astral_summon_nature_4",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_nature_5",
+    "name": "bonus_magic_astral_summon_nature_5",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_unfrozen_1",
+    "name": "bonus_magic_astral_summon_unfrozen_1",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_unfrozen_2",
+    "name": "bonus_magic_astral_summon_unfrozen_2",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_unfrozen_3",
+    "name": "bonus_magic_astral_summon_unfrozen_3",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_unfrozen_4",
+    "name": "bonus_magic_astral_summon_unfrozen_4",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "bonus_magic_astral_summon_unfrozen_5",
+    "name": "bonus_magic_astral_summon_unfrozen_5",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "neutral_magic_shadow_form",
+    "name": "Shadowflight",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "neutral_magic_town_portal",
+    "name": "Town Portal",
+    "school": "neutral",
+    "tier": 3
+  },
+  {
+    "id": "neutral_magic_dimension_door",
+    "name": "Dimension Door",
+    "school": "neutral",
+    "tier": 4
+  },
+  {
+    "id": "neutral_magic_light_gate",
+    "name": "Gate of Light",
+    "school": "neutral",
+    "tier": 4
+  },
+  {
+    "id": "night_4_magic_despair",
+    "name": "Despair",
+    "school": "night",
+    "tier": 1
+  },
+  {
+    "id": "night_3_magic_enlarge_shadow",
+    "name": "Enlarge Shadow",
+    "school": "night",
+    "tier": 1
+  },
+  {
+    "id": "night_7_magic_fatal_decay",
+    "name": "Fatal Decay",
+    "school": "night",
+    "tier": 1
+  },
+  {
+    "id": "night_1_magic_unnatural_calm",
+    "name": "Unnatural Calm",
+    "school": "night",
+    "tier": 1
+  },
+  {
+    "id": "night_17_magic_read_minds",
+    "name": "Read Minds",
+    "school": "night",
+    "tier": 2
+  },
+  {
+    "id": "night_5_magic_shade_cloak",
+    "name": "Shade Cloak",
+    "school": "night",
+    "tier": 2
+  },
+  {
+    "id": "night_6_magic_deaths_grip",
+    "name": "Umbral Grip",
+    "school": "night",
+    "tier": 2
+  },
+  {
+    "id": "night_2_magic_web",
+    "name": "Web",
+    "school": "night",
+    "tier": 2
+  },
+  {
+    "id": "night_18_magic_nairas_veil",
+    "name": "Naira’s Veil",
+    "school": "night",
+    "tier": 3
+  },
+  {
+    "id": "night_10_magic_silence",
+    "name": "Silence",
+    "school": "night",
+    "tier": 3
+  },
+  {
+    "id": "night_8_magic_sleep",
+    "name": "Sleep",
+    "school": "night",
+    "tier": 3
+  },
+  {
+    "id": "night_9_magic_twilight",
+    "name": "Twilight",
+    "school": "night",
+    "tier": 3
+  },
+  {
+    "id": "night_13_magic_berserker",
+    "name": "Berserk",
+    "school": "night",
+    "tier": 4
+  },
+  {
+    "id": "night_12_magic_summon_starchild",
+    "name": "Summon Starchild",
+    "school": "night",
+    "tier": 4
+  },
+  {
+    "id": "night_11_magic_vulnerability",
+    "name": "Vulnerability",
+    "school": "night",
+    "tier": 4
+  },
+  {
+    "id": "night_15_magic_deaths_call",
+    "name": "Coup de Grâce",
+    "school": "night",
+    "tier": 5
+  },
+  {
+    "id": "night_14_magic_nairas_kiss",
+    "name": "Naira’s Kiss",
+    "school": "night",
+    "tier": 5
+  },
+  {
+    "id": "night_16_magic_shadow_army",
+    "name": "Shadow Army",
+    "school": "night",
+    "tier": 5
+  },
+  {
+    "id": "primal_17_magic_groundsight",
+    "name": "Groundsight",
+    "school": "primal",
+    "tier": 1
+  },
+  {
+    "id": "primal_1_magic_thunderbolt",
+    "name": "Lightning Bolt",
+    "school": "primal",
+    "tier": 1
+  },
+  {
+    "id": "primal_2_magic_thick_hide",
+    "name": "Thick Hide",
+    "school": "primal",
+    "tier": 1
+  },
+  {
+    "id": "primal_5_magic_crystal_crown",
+    "name": "Crystal Crown",
+    "school": "primal",
+    "tier": 2
+  },
+  {
+    "id": "primal_4_magic_fire_globe",
+    "name": "Fireball",
+    "school": "primal",
+    "tier": 2
+  },
+  {
+    "id": "primal_6_magic_ice_bolt",
+    "name": "Ice Bolt",
+    "school": "primal",
+    "tier": 2
+  },
+  {
+    "id": "primal_3_magic_wean",
+    "name": "Wean",
+    "school": "primal",
+    "tier": 2
+  },
+  {
+    "id": "primal_8_magic_cave_in",
+    "name": "Cave In",
+    "school": "primal",
+    "tier": 3
+  },
+  {
+    "id": "primal_9_magic_earths_rage",
+    "name": "Earth’s Rage",
+    "school": "primal",
+    "tier": 3
+  },
+  {
+    "id": "primal_7_magic_wall_of_flame",
+    "name": "Firewall",
+    "school": "primal",
+    "tier": 3
+  },
+  {
+    "id": "primal_16_magic_stone_fangs",
+    "name": "Stone Fangs",
+    "school": "primal",
+    "tier": 3
+  },
+  {
+    "id": "primal_10_magic_primordial_purity",
+    "name": "Anti‑Magic",
+    "school": "primal",
+    "tier": 4
+  },
+  {
+    "id": "primal_12_magic_chain_lightning",
+    "name": "Chain Lightning",
+    "school": "primal",
+    "tier": 4
+  },
+  {
+    "id": "primal_13_magic_avalanche",
+    "name": "Circle of Winter",
+    "school": "primal",
+    "tier": 4
+  },
+  {
+    "id": "primal_18_magic_primordial_chaos",
+    "name": "Primordial Chaos",
+    "school": "primal",
+    "tier": 4
+  },
+  {
+    "id": "primal_11_magic_armageddon",
+    "name": "Armageddon",
+    "school": "primal",
+    "tier": 5
+  },
+  {
+    "id": "primal_14_magic_hksmillas_rampage",
+    "name": "Hksmilla’s Rampage",
+    "school": "primal",
+    "tier": 5
+  },
+  {
+    "id": "primal_15_magic_summon_primal_remnant",
+    "name": "Summon Primal Remnant",
+    "school": "primal",
+    "tier": 5
+  },
+  {
+    "id": "space_1_magic_early_start",
+    "name": "Early Start",
+    "school": "space",
+    "tier": 1
+  },
+  {
+    "id": "space_3_magic_energyze",
+    "name": "Energize",
+    "school": "space",
+    "tier": 1
+  },
+  {
+    "id": "space_11_magic_decimate",
+    "name": "Guillotine",
+    "school": "space",
+    "tier": 1
+  },
+  {
+    "id": "space_4_magic_optical_illusion",
+    "name": "Optical Illusion",
+    "school": "space",
+    "tier": 1
+  },
+  {
+    "id": "space_6_magic_blink",
+    "name": "Blink",
+    "school": "space",
+    "tier": 2
+  },
+  {
+    "id": "space_8_magic_carapace",
+    "name": "Carapace",
+    "school": "space",
+    "tier": 2
+  },
+  {
+    "id": "space_2_magic_energy_explosion",
+    "name": "Energy Explosion",
+    "school": "space",
+    "tier": 2
+  },
+  {
+    "id": "space_17_magic_reinforcements",
+    "name": "Reinforcements",
+    "school": "space",
+    "tier": 2
+  },
+  {
+    "id": "space_18_magic_assemble",
+    "name": "Assemble!",
+    "school": "space",
+    "tier": 3
+  },
+  {
+    "id": "space_9_magic_impending_fate",
+    "name": "Impending Fate",
+    "school": "space",
+    "tier": 3
+  },
+  {
+    "id": "space_7_magic_shackles",
+    "name": "Shackles",
+    "school": "space",
+    "tier": 3
+  },
+  {
+    "id": "space_5_magic_trap_jaws",
+    "name": "Temporal Spheres",
+    "school": "space",
+    "tier": 3
+  },
+  {
+    "id": "space_10_magic_mirror_copy",
+    "name": "Mirror Copy",
+    "school": "space",
+    "tier": 4
+  },
+  {
+    "id": "space_12_magic_rewind",
+    "name": "Rewind Life",
+    "school": "space",
+    "tier": 4
+  },
+  {
+    "id": "space_15_magic_trap_snare",
+    "name": "Spatial Snare",
+    "school": "space",
+    "tier": 4
+  },
+  {
+    "id": "space_13_magic_black_hole",
+    "name": "Black Hole",
+    "school": "space",
+    "tier": 5
+  },
+  {
+    "id": "space_14_magic_doreaths_tide",
+    "name": "Doreath’s Tide",
+    "school": "space",
+    "tier": 5
+  },
+  {
+    "id": "space_16_magic_reality_distortion",
+    "name": "Reality Distortion",
+    "school": "space",
+    "tier": 5
+  }
+]

--- a/Olden Era - Template Editor/ItemPickerWindow.xaml
+++ b/Olden Era - Template Editor/ItemPickerWindow.xaml
@@ -1,0 +1,88 @@
+<Window x:Class="Olden_Era___Template_Editor.ItemPickerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Select to Ban" Width="900" Height="760"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize"
+        MinWidth="500" MinHeight="400"
+        Background="#221E15"
+        Foreground="#E8D5A3"
+        FontFamily="Segoe UI" FontSize="13">
+
+    <DockPanel Margin="12">
+
+        <!-- Search box -->
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+            <TextBox x:Name="TxtSearch"
+                     TextChanged="TxtSearch_TextChanged"
+                     Height="28"
+                     Background="#2C2619" Foreground="#E8D5A3"
+                     BorderBrush="#5A4A28" BorderThickness="1"
+                     CaretBrush="#C9A84C" SelectionBrush="#8A6E30"
+                     Padding="6,0"/>
+            <!-- placeholder via triggers: not needed, WPF ≥ 4.5 has no native placeholder -->
+        </StackPanel>
+
+        <!-- Buttons -->
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
+                    HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button x:Name="BtnAdd" Content="Add Selected"
+                    Width="110" Height="28" Margin="0,0,8,0"
+                    IsDefault="True"
+                    Click="BtnAdd_Click"/>
+            <Button Content="Cancel"
+                    Width="80" Height="28"
+                    IsCancel="True"
+                    Click="BtnCancel_Click"/>
+        </StackPanel>
+
+        <!-- Custom ID row -->
+        <Grid DockPanel.Dock="Bottom" Margin="0,6,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="8"/>
+                <ColumnDefinition Width="110"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="Custom ID:"
+                       VerticalAlignment="Center" Margin="0,0,6,0"
+                       Foreground="#9A8A6A" FontSize="12"/>
+            <TextBox Grid.Column="1" x:Name="TxtCustomId"
+                     Height="26" FontFamily="Consolas" FontSize="11"
+                     Background="#2C2619" Foreground="#E8D5A3"
+                     BorderBrush="#5A4A28" BorderThickness="1"
+                     CaretBrush="#C9A84C"
+                     ToolTip="Type any ID not found in the list above"/>
+            <Button Grid.Column="3" Content="Add Custom"
+                    Height="26"
+                    Click="BtnAddCustom_Click"/>
+        </Grid>
+
+        <!-- Category tree -->
+        <TreeView x:Name="TvItems"
+                  SelectedItemChanged="TvItems_SelectedItemChanged"
+                  MouseDoubleClick="TvItems_MouseDoubleClick"
+                  Background="#2C2619"
+                  Foreground="#E8D5A3"
+                  BorderBrush="#5A4A28" BorderThickness="1">
+            <TreeView.Resources>
+                <!-- Dark-theme TreeViewItem -->
+                <Style TargetType="TreeViewItem">
+                    <Setter Property="Background"  Value="Transparent"/>
+                    <Setter Property="Foreground"  Value="#E8D5A3"/>
+                    <Setter Property="Padding"     Value="3,2"/>
+                    <Setter Property="IsExpanded"  Value="True"/>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#3A3020"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter Property="Background" Value="#5A4A28"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TreeView.Resources>
+        </TreeView>
+
+    </DockPanel>
+</Window>

--- a/Olden Era - Template Editor/ItemPickerWindow.xaml
+++ b/Olden Era - Template Editor/ItemPickerWindow.xaml
@@ -20,14 +20,13 @@
                      BorderBrush="#5A4A28" BorderThickness="1"
                      CaretBrush="#C9A84C" SelectionBrush="#8A6E30"
                      Padding="6,0"/>
-            <!-- placeholder via triggers: not needed, WPF ≥ 4.5 has no native placeholder -->
         </StackPanel>
 
         <!-- Buttons -->
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
                     HorizontalAlignment="Right" Margin="0,8,0,0">
             <Button x:Name="BtnAdd" Content="Add Selected"
-                    Width="110" Height="28" Margin="0,0,8,0"
+                    Width="120" Height="28" Margin="0,0,8,0"
                     IsDefault="True"
                     Click="BtnAdd_Click"/>
             <Button Content="Cancel"
@@ -60,13 +59,13 @@
 
         <!-- Category tree -->
         <TreeView x:Name="TvItems"
-                  SelectedItemChanged="TvItems_SelectedItemChanged"
+                  PreviewMouseLeftButtonDown="TvItems_PreviewMouseLeftButtonDown"
                   MouseDoubleClick="TvItems_MouseDoubleClick"
                   Background="#2C2619"
                   Foreground="#E8D5A3"
                   BorderBrush="#5A4A28" BorderThickness="1">
             <TreeView.Resources>
-                <!-- Dark-theme TreeViewItem -->
+                <!-- Dark-theme TreeViewItem — selection highlight managed in code -->
                 <Style TargetType="TreeViewItem">
                     <Setter Property="Background"  Value="Transparent"/>
                     <Setter Property="Foreground"  Value="#E8D5A3"/>
@@ -77,7 +76,8 @@
                             <Setter Property="Background" Value="#3A3020"/>
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter Property="Background" Value="#5A4A28"/>
+                            <!-- suppress built-in blue highlight; our code sets Background directly -->
+                            <Setter Property="Background" Value="Transparent"/>
                         </Trigger>
                     </Style.Triggers>
                 </Style>

--- a/Olden Era - Template Editor/ItemPickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/ItemPickerWindow.xaml.cs
@@ -11,17 +11,22 @@ namespace Olden_Era___Template_Editor
 {
     public partial class ItemPickerWindow : Window
     {
-        public string? SelectedId { get; private set; }
+        /// <summary>First selected ID (kept for callers that only need one).</summary>
+        public string?      SelectedId  => SelectedIds.Count > 0 ? SelectedIds[0] : null;
+        public List<string> SelectedIds { get; private set; } = [];
 
-        private readonly List<BanEntry> _allEntries;
-        private readonly HashSet<string> _alreadyBanned;
-        // Categories that the user has manually collapsed — preserved across searches.
-        private readonly HashSet<string> _collapsedCategories = [];
+        private readonly List<BanEntry>         _allEntries;
+        private readonly HashSet<string>         _alreadyBanned;
+        private readonly HashSet<string>         _collapsedCategories = [];
+        private readonly HashSet<TreeViewItem>   _checkedLeaves       = [];
+
+        private static readonly SolidColorBrush CheckedBrush  = new(Color.FromRgb(0x5A, 0x4A, 0x28));
+        private static readonly SolidColorBrush CheckMarkBrush = new(Color.FromRgb(0xC9, 0xA8, 0x4C));
 
         public ItemPickerWindow(IEnumerable<BanEntry> entries, IEnumerable<string> alreadyBanned, string windowTitle)
         {
             InitializeComponent();
-            Title = windowTitle;
+            Title          = windowTitle;
             _allEntries    = [.. entries];
             _alreadyBanned = [.. alreadyBanned];
             RefreshTree(string.Empty);
@@ -32,7 +37,6 @@ namespace Olden_Era___Template_Editor
 
         private void RefreshTree(string filter)
         {
-            // Remember which categories the user collapsed between refreshes.
             foreach (TreeViewItem ci in TvItems.Items)
                 if (ci.Tag is string cat)
                 {
@@ -40,6 +44,7 @@ namespace Olden_Era___Template_Editor
                     else               _collapsedCategories.Add(cat);
                 }
 
+            _checkedLeaves.Clear();
             TvItems.Items.Clear();
 
             var groups = _allEntries
@@ -66,7 +71,7 @@ namespace Olden_Era___Template_Editor
                 TvItems.Items.Add(catNode);
             }
 
-            BtnAdd.IsEnabled = SelectedLeaf() != null;
+            UpdateAddButton();
         }
 
         private static FrameworkElement BuildCategoryHeader(string category, int count)
@@ -92,7 +97,20 @@ namespace Olden_Era___Template_Editor
 
         private static TreeViewItem BuildLeafItem(BanEntry entry)
         {
+            // Check mark placeholder — toggled in code
+            var chk = new TextBlock
+            {
+                Name              = "ChkMark",
+                Text              = "",     // filled with ✓ when checked
+                Width             = 16,
+                Foreground        = CheckMarkBrush,
+                FontWeight        = FontWeights.Bold,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin            = new Thickness(0, 0, 4, 0),
+            };
+
             var sp = new StackPanel { Orientation = System.Windows.Controls.Orientation.Horizontal };
+            sp.Children.Add(chk);
             sp.Children.Add(new Ellipse
             {
                 Width  = 9, Height = 9,
@@ -102,10 +120,10 @@ namespace Olden_Era___Template_Editor
             });
             sp.Children.Add(new TextBlock
             {
-                Text   = entry.DisplayName,
-                Width  = 220,
+                Text       = entry.DisplayName,
+                Width      = 220,
                 Foreground = new SolidColorBrush(Color.FromRgb(0xE8, 0xD5, 0xA3)),
-                Margin = new Thickness(0, 0, 14, 0),
+                Margin     = new Thickness(0, 0, 14, 0),
                 VerticalAlignment = VerticalAlignment.Center,
             });
             sp.Children.Add(new TextBlock
@@ -120,13 +138,48 @@ namespace Olden_Era___Template_Editor
             return new TreeViewItem { Header = sp, Tag = entry };
         }
 
-        private BanEntry? SelectedLeaf()
-            => TvItems.SelectedItem is TreeViewItem { Tag: BanEntry entry } ? entry : null;
+        // ── Check-toggle helpers ─────────────────────────────────────────────────
 
-        private void Commit(string id)
+        private static TextBlock? GetCheckMark(TreeViewItem item)
+            => item.Header is StackPanel sp && sp.Children.Count > 0
+                ? sp.Children[0] as TextBlock
+                : null;
+
+        private void ToggleLeaf(TreeViewItem item)
         {
-            SelectedId   = id;
-            DialogResult = true;
+            if (_checkedLeaves.Contains(item))
+            {
+                _checkedLeaves.Remove(item);
+                item.Background = DependencyProperty.UnsetValue as Brush; // reset
+                item.ClearValue(TreeViewItem.BackgroundProperty);
+                if (GetCheckMark(item) is { } chk) chk.Text = "";
+            }
+            else
+            {
+                _checkedLeaves.Add(item);
+                item.Background = CheckedBrush;
+                if (GetCheckMark(item) is { } chk) chk.Text = "✓";
+            }
+            UpdateAddButton();
+        }
+
+        private void UpdateAddButton()
+        {
+            int n = _checkedLeaves.Count;
+            BtnAdd.Content   = n > 1 ? $"Add Selected ({n})" : "Add Selected";
+            BtnAdd.IsEnabled = n > 0;
+        }
+
+        private static TreeViewItem? FindLeafFromSource(object originalSource)
+        {
+            var dep = originalSource as DependencyObject;
+            while (dep != null)
+            {
+                if (dep is TreeViewItem tvi && tvi.Tag is BanEntry)
+                    return tvi;
+                dep = VisualTreeHelper.GetParent(dep);
+            }
+            return null;
         }
 
         // ── Event handlers ────────────────────────────────────────────────────────
@@ -134,26 +187,43 @@ namespace Olden_Era___Template_Editor
         private void TxtSearch_TextChanged(object sender, TextChangedEventArgs e)
             => RefreshTree(TxtSearch.Text);
 
-        private void TvItems_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
-            => BtnAdd.IsEnabled = SelectedLeaf() != null;
+        private void TvItems_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var leaf = FindLeafFromSource(e.OriginalSource);
+            if (leaf == null) return; // category header click — let it expand/collapse normally
+            ToggleLeaf(leaf);
+            e.Handled = true; // suppress built-in selection highlight
+        }
 
         private void TvItems_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (SelectedLeaf() is BanEntry entry)
-                Commit(entry.Id);
+            var leaf = FindLeafFromSource(e.OriginalSource);
+            if (leaf == null) return;
+            // Ensure it's checked, then commit
+            if (!_checkedLeaves.Contains(leaf)) ToggleLeaf(leaf);
+            CommitAll();
+        }
+
+        private void CommitAll()
+        {
+            SelectedIds = _checkedLeaves
+                .Select(tvi => ((BanEntry)tvi.Tag!).Id)
+                .ToList();
+            if (SelectedIds.Count > 0)
+                DialogResult = true;
         }
 
         private void BtnAdd_Click(object sender, RoutedEventArgs e)
-        {
-            if (SelectedLeaf() is BanEntry entry)
-                Commit(entry.Id);
-        }
+            => CommitAll();
 
         private void BtnAddCustom_Click(object sender, RoutedEventArgs e)
         {
             var id = TxtCustomId.Text.Trim();
             if (!string.IsNullOrEmpty(id))
-                Commit(id);
+            {
+                SelectedIds  = [id];
+                DialogResult = true;
+            }
         }
 
         private void BtnCancel_Click(object sender, RoutedEventArgs e)

--- a/Olden Era - Template Editor/ItemPickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/ItemPickerWindow.xaml.cs
@@ -1,0 +1,162 @@
+using OldenEraTemplateEditor.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace Olden_Era___Template_Editor
+{
+    public partial class ItemPickerWindow : Window
+    {
+        public string? SelectedId { get; private set; }
+
+        private readonly List<BanEntry> _allEntries;
+        private readonly HashSet<string> _alreadyBanned;
+        // Categories that the user has manually collapsed — preserved across searches.
+        private readonly HashSet<string> _collapsedCategories = [];
+
+        public ItemPickerWindow(IEnumerable<BanEntry> entries, IEnumerable<string> alreadyBanned, string windowTitle)
+        {
+            InitializeComponent();
+            Title = windowTitle;
+            _allEntries    = [.. entries];
+            _alreadyBanned = [.. alreadyBanned];
+            RefreshTree(string.Empty);
+            TxtSearch.Focus();
+        }
+
+        // ── Tree building ─────────────────────────────────────────────────────────
+
+        private void RefreshTree(string filter)
+        {
+            // Remember which categories the user collapsed between refreshes.
+            foreach (TreeViewItem ci in TvItems.Items)
+                if (ci.Tag is string cat)
+                {
+                    if (ci.IsExpanded) _collapsedCategories.Remove(cat);
+                    else               _collapsedCategories.Add(cat);
+                }
+
+            TvItems.Items.Clear();
+
+            var groups = _allEntries
+                .Where(e => !_alreadyBanned.Contains(e.Id))
+                .Where(e => string.IsNullOrEmpty(filter)
+                         || e.DisplayName.Contains(filter, System.StringComparison.OrdinalIgnoreCase)
+                         || e.Category.Contains(filter,    System.StringComparison.OrdinalIgnoreCase)
+                         || e.Id.Contains(filter,          System.StringComparison.OrdinalIgnoreCase))
+                .GroupBy(e => e.Category)
+                .OrderBy(g => g.Key);
+
+            foreach (var group in groups)
+            {
+                var catNode = new TreeViewItem
+                {
+                    Tag        = group.Key,
+                    IsExpanded = !_collapsedCategories.Contains(group.Key),
+                    Header     = BuildCategoryHeader(group.Key, group.Count()),
+                };
+
+                foreach (var entry in group.OrderBy(e => e.DisplayName))
+                    catNode.Items.Add(BuildLeafItem(entry));
+
+                TvItems.Items.Add(catNode);
+            }
+
+            BtnAdd.IsEnabled = SelectedLeaf() != null;
+        }
+
+        private static FrameworkElement BuildCategoryHeader(string category, int count)
+        {
+            var sp = new StackPanel { Orientation = System.Windows.Controls.Orientation.Horizontal };
+            sp.Children.Add(new TextBlock
+            {
+                Text       = category,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(Color.FromRgb(0xC9, 0xA8, 0x4C)),
+                Margin     = new Thickness(0, 0, 6, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            sp.Children.Add(new TextBlock
+            {
+                Text      = $"({count})",
+                Foreground = new SolidColorBrush(Color.FromRgb(0x9A, 0x8A, 0x6A)),
+                FontSize  = 11,
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            return sp;
+        }
+
+        private static TreeViewItem BuildLeafItem(BanEntry entry)
+        {
+            var sp = new StackPanel { Orientation = System.Windows.Controls.Orientation.Horizontal };
+            sp.Children.Add(new Ellipse
+            {
+                Width  = 9, Height = 9,
+                Fill   = entry.CategoryBrush,
+                Margin = new Thickness(0, 0, 7, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            sp.Children.Add(new TextBlock
+            {
+                Text   = entry.DisplayName,
+                Width  = 220,
+                Foreground = new SolidColorBrush(Color.FromRgb(0xE8, 0xD5, 0xA3)),
+                Margin = new Thickness(0, 0, 14, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            sp.Children.Add(new TextBlock
+            {
+                Text       = entry.Id,
+                FontFamily = new FontFamily("Consolas"),
+                FontSize   = 11,
+                Foreground = new SolidColorBrush(Color.FromRgb(0x9A, 0x8A, 0x6A)),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+
+            return new TreeViewItem { Header = sp, Tag = entry };
+        }
+
+        private BanEntry? SelectedLeaf()
+            => TvItems.SelectedItem is TreeViewItem { Tag: BanEntry entry } ? entry : null;
+
+        private void Commit(string id)
+        {
+            SelectedId   = id;
+            DialogResult = true;
+        }
+
+        // ── Event handlers ────────────────────────────────────────────────────────
+
+        private void TxtSearch_TextChanged(object sender, TextChangedEventArgs e)
+            => RefreshTree(TxtSearch.Text);
+
+        private void TvItems_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+            => BtnAdd.IsEnabled = SelectedLeaf() != null;
+
+        private void TvItems_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (SelectedLeaf() is BanEntry entry)
+                Commit(entry.Id);
+        }
+
+        private void BtnAdd_Click(object sender, RoutedEventArgs e)
+        {
+            if (SelectedLeaf() is BanEntry entry)
+                Commit(entry.Id);
+        }
+
+        private void BtnAddCustom_Click(object sender, RoutedEventArgs e)
+        {
+            var id = TxtCustomId.Text.Trim();
+            if (!string.IsNullOrEmpty(id))
+                Commit(id);
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e)
+            => DialogResult = false;
+    }
+}

--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -656,13 +656,24 @@
                             </Border>
 
                             <!-- Value overrides (kept as free-text) -->
-                            <Label Content="Value overrides (one per line: sid=guardValue)" Padding="0,0,0,2"
-                                   Foreground="#E8D5A3" FontSize="12"/>
-                            <TextBox x:Name="TxtValueOverrides"
-                                     AcceptsReturn="True" Height="68" TextWrapping="NoWrap"
-                                     VerticalScrollBarVisibility="Auto"
-                                     FontFamily="Consolas" FontSize="11"
-                                     TextChanged="BansOverrides_TextChanged"/>
+                            <TextBlock Text="Value overrides (one per line: sid=guardValue)"
+                                       Foreground="#E8D5A3" FontSize="12" Margin="0,0,0,4"/>
+                            <Border Background="#2C2619" BorderBrush="#5A4A28" BorderThickness="1">
+                                <DockPanel>
+                                    <Button DockPanel.Dock="Left" x:Name="BtnPickValueOverride"
+                                            Content="+" Width="28"
+                                            Click="BtnPickValueOverride_Click"
+                                            Background="#1E1A10" BorderBrush="#7A6A48" BorderThickness="0,0,1,0"
+                                            Foreground="#C8B87A" FontSize="16"
+                                            VerticalAlignment="Stretch" Cursor="Hand"/>
+                                    <TextBox x:Name="TxtValueOverrides"
+                                             AcceptsReturn="True" Height="68" TextWrapping="NoWrap"
+                                             VerticalScrollBarVisibility="Auto"
+                                             Background="Transparent" BorderThickness="0"
+                                             FontFamily="Consolas" FontSize="11"
+                                             TextChanged="BansOverrides_TextChanged"/>
+                                </DockPanel>
+                            </Border>
                         </StackPanel>
                     </Border>
                 </DockPanel>

--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -451,6 +451,130 @@
                                               Checked="ChkOption_Changed"
                                               Unchecked="ChkOption_Changed"/>
                                                 </Grid>
+
+                                <Separator Margin="0,12,0,8"/>
+                                <TextBlock Text="◆  BANS &amp; OVERRIDES" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+
+                                <!-- Banned Items -->
+                                <DockPanel Margin="0,0,0,4">
+                                    <TextBlock DockPanel.Dock="Left" Text="Banned items"
+                                               Foreground="#E8D5A3" FontSize="12"
+                                               VerticalAlignment="Center"/>
+                                    <Button DockPanel.Dock="Right" Content="+ Add"
+                                            x:Name="BtnAddBannedItem"
+                                            Width="54" Height="22"
+                                            Click="BtnAddBannedItem_Click"/>
+                                </DockPanel>
+                                <ListBox x:Name="LbBannedItems"
+                                         MinHeight="32" MaxHeight="130"
+                                         Background="#2C2619"
+                                         BorderBrush="#5A4A28" BorderThickness="1"
+                                         Margin="0,0,0,10"
+                                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                    <ListBox.ItemContainerStyle>
+                                        <Style TargetType="ListBoxItem">
+                                            <Setter Property="Padding"    Value="0"/>
+                                            <Setter Property="Margin"     Value="0"/>
+                                            <Setter Property="Background" Value="Transparent"/>
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="ListBoxItem">
+                                                        <ContentPresenter/>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </ListBox.ItemContainerStyle>
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <DockPanel Margin="4,2">
+                                                <Button DockPanel.Dock="Right"
+                                                        Content="×" Width="20" Height="18"
+                                                        FontSize="13" Padding="0"
+                                                        Tag="{Binding Id}"
+                                                        Click="RemoveBannedItem_Click"
+                                                        ToolTip="Remove"
+                                                        Background="#3A2820"
+                                                        BorderBrush="#5A4A28"
+                                                        Foreground="#E8D5A3"/>
+                                                <Ellipse Width="8" Height="8"
+                                                         Fill="{Binding CategoryBrush}"
+                                                         VerticalAlignment="Center"
+                                                         Margin="0,0,6,0"/>
+                                                <TextBlock Text="{Binding DisplayName}"
+                                                           Foreground="#E8D5A3" FontSize="12"
+                                                           VerticalAlignment="Center"/>
+                                                <TextBlock Text="{Binding Category}"
+                                                           Foreground="#9A8A6A" FontSize="11"
+                                                           VerticalAlignment="Center"
+                                                           Margin="6,0,0,0"/>
+                                            </DockPanel>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+
+                                <!-- Banned Spells -->
+                                <DockPanel Margin="0,0,0,4">
+                                    <TextBlock DockPanel.Dock="Left" Text="Banned spells"
+                                               Foreground="#E8D5A3" FontSize="12"
+                                               VerticalAlignment="Center"/>
+                                    <Button DockPanel.Dock="Right" Content="+ Add"
+                                            x:Name="BtnAddBannedMagic"
+                                            Width="54" Height="22"
+                                            Click="BtnAddBannedMagic_Click"/>
+                                </DockPanel>
+                                <ListBox x:Name="LbBannedMagics"
+                                         MinHeight="32" MaxHeight="130"
+                                         Background="#2C2619"
+                                         BorderBrush="#5A4A28" BorderThickness="1"
+                                         Margin="0,0,0,10"
+                                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                    <ListBox.ItemContainerStyle>
+                                        <Style TargetType="ListBoxItem">
+                                            <Setter Property="Padding"    Value="0"/>
+                                            <Setter Property="Margin"     Value="0"/>
+                                            <Setter Property="Background" Value="Transparent"/>
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="ListBoxItem">
+                                                        <ContentPresenter/>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </ListBox.ItemContainerStyle>
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <DockPanel Margin="4,2">
+                                                <Button DockPanel.Dock="Right"
+                                                        Content="×" Width="20" Height="18"
+                                                        FontSize="13" Padding="0"
+                                                        Tag="{Binding Id}"
+                                                        Click="RemoveBannedMagic_Click"
+                                                        ToolTip="Remove"
+                                                        Background="#3A2820"
+                                                        BorderBrush="#5A4A28"
+                                                        Foreground="#E8D5A3"/>
+                                                <Ellipse Width="8" Height="8"
+                                                         Fill="{Binding CategoryBrush}"
+                                                         VerticalAlignment="Center"
+                                                         Margin="0,0,6,0"/>
+                                                <TextBlock Text="{Binding DisplayName}"
+                                                           Foreground="#E8D5A3" FontSize="12"
+                                                           VerticalAlignment="Center"/>
+                                            </DockPanel>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+
+                                <!-- Value overrides (kept as free-text) -->
+                                <Label Content="Value overrides (one per line: sid=guardValue)" Padding="0,0,0,2"
+                                       Foreground="#E8D5A3" FontSize="12"/>
+                                <TextBox x:Name="TxtValueOverrides"
+                                         AcceptsReturn="True" Height="68" TextWrapping="NoWrap"
+                                         VerticalScrollBarVisibility="Auto"
+                                         FontFamily="Consolas" FontSize="11"
+                                         TextChanged="BansOverrides_TextChanged"/>
                                             </StackPanel>
                                         </StackPanel>
                                     </ScrollViewer>

--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -452,129 +452,7 @@
                                               Unchecked="ChkOption_Changed"/>
                                                 </Grid>
 
-                                <Separator Margin="0,12,0,8"/>
-                                <TextBlock Text="◆  BANS &amp; OVERRIDES" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
 
-                                <!-- Banned Items -->
-                                <DockPanel Margin="0,0,0,4">
-                                    <TextBlock DockPanel.Dock="Left" Text="Banned items"
-                                               Foreground="#E8D5A3" FontSize="12"
-                                               VerticalAlignment="Center"/>
-                                    <Button DockPanel.Dock="Right" Content="+ Add"
-                                            x:Name="BtnAddBannedItem"
-                                            Width="54" Height="22"
-                                            Click="BtnAddBannedItem_Click"/>
-                                </DockPanel>
-                                <ListBox x:Name="LbBannedItems"
-                                         MinHeight="32" MaxHeight="130"
-                                         Background="#2C2619"
-                                         BorderBrush="#5A4A28" BorderThickness="1"
-                                         Margin="0,0,0,10"
-                                         ScrollViewer.VerticalScrollBarVisibility="Auto">
-                                    <ListBox.ItemContainerStyle>
-                                        <Style TargetType="ListBoxItem">
-                                            <Setter Property="Padding"    Value="0"/>
-                                            <Setter Property="Margin"     Value="0"/>
-                                            <Setter Property="Background" Value="Transparent"/>
-                                            <Setter Property="Template">
-                                                <Setter.Value>
-                                                    <ControlTemplate TargetType="ListBoxItem">
-                                                        <ContentPresenter/>
-                                                    </ControlTemplate>
-                                                </Setter.Value>
-                                            </Setter>
-                                        </Style>
-                                    </ListBox.ItemContainerStyle>
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <DockPanel Margin="4,2">
-                                                <Button DockPanel.Dock="Right"
-                                                        Content="×" Width="20" Height="18"
-                                                        FontSize="13" Padding="0"
-                                                        Tag="{Binding Id}"
-                                                        Click="RemoveBannedItem_Click"
-                                                        ToolTip="Remove"
-                                                        Background="#3A2820"
-                                                        BorderBrush="#5A4A28"
-                                                        Foreground="#E8D5A3"/>
-                                                <Ellipse Width="8" Height="8"
-                                                         Fill="{Binding CategoryBrush}"
-                                                         VerticalAlignment="Center"
-                                                         Margin="0,0,6,0"/>
-                                                <TextBlock Text="{Binding DisplayName}"
-                                                           Foreground="#E8D5A3" FontSize="12"
-                                                           VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding Category}"
-                                                           Foreground="#9A8A6A" FontSize="11"
-                                                           VerticalAlignment="Center"
-                                                           Margin="6,0,0,0"/>
-                                            </DockPanel>
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-                                </ListBox>
-
-                                <!-- Banned Spells -->
-                                <DockPanel Margin="0,0,0,4">
-                                    <TextBlock DockPanel.Dock="Left" Text="Banned spells"
-                                               Foreground="#E8D5A3" FontSize="12"
-                                               VerticalAlignment="Center"/>
-                                    <Button DockPanel.Dock="Right" Content="+ Add"
-                                            x:Name="BtnAddBannedMagic"
-                                            Width="54" Height="22"
-                                            Click="BtnAddBannedMagic_Click"/>
-                                </DockPanel>
-                                <ListBox x:Name="LbBannedMagics"
-                                         MinHeight="32" MaxHeight="130"
-                                         Background="#2C2619"
-                                         BorderBrush="#5A4A28" BorderThickness="1"
-                                         Margin="0,0,0,10"
-                                         ScrollViewer.VerticalScrollBarVisibility="Auto">
-                                    <ListBox.ItemContainerStyle>
-                                        <Style TargetType="ListBoxItem">
-                                            <Setter Property="Padding"    Value="0"/>
-                                            <Setter Property="Margin"     Value="0"/>
-                                            <Setter Property="Background" Value="Transparent"/>
-                                            <Setter Property="Template">
-                                                <Setter.Value>
-                                                    <ControlTemplate TargetType="ListBoxItem">
-                                                        <ContentPresenter/>
-                                                    </ControlTemplate>
-                                                </Setter.Value>
-                                            </Setter>
-                                        </Style>
-                                    </ListBox.ItemContainerStyle>
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <DockPanel Margin="4,2">
-                                                <Button DockPanel.Dock="Right"
-                                                        Content="×" Width="20" Height="18"
-                                                        FontSize="13" Padding="0"
-                                                        Tag="{Binding Id}"
-                                                        Click="RemoveBannedMagic_Click"
-                                                        ToolTip="Remove"
-                                                        Background="#3A2820"
-                                                        BorderBrush="#5A4A28"
-                                                        Foreground="#E8D5A3"/>
-                                                <Ellipse Width="8" Height="8"
-                                                         Fill="{Binding CategoryBrush}"
-                                                         VerticalAlignment="Center"
-                                                         Margin="0,0,6,0"/>
-                                                <TextBlock Text="{Binding DisplayName}"
-                                                           Foreground="#E8D5A3" FontSize="12"
-                                                           VerticalAlignment="Center"/>
-                                            </DockPanel>
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-                                </ListBox>
-
-                                <!-- Value overrides (kept as free-text) -->
-                                <Label Content="Value overrides (one per line: sid=guardValue)" Padding="0,0,0,2"
-                                       Foreground="#E8D5A3" FontSize="12"/>
-                                <TextBox x:Name="TxtValueOverrides"
-                                         AcceptsReturn="True" Height="68" TextWrapping="NoWrap"
-                                         VerticalScrollBarVisibility="Auto"
-                                         FontFamily="Consolas" FontSize="11"
-                                         TextChanged="BansOverrides_TextChanged"/>
                                             </StackPanel>
                                         </StackPanel>
                                     </ScrollViewer>
@@ -583,29 +461,32 @@
                     </Grid>
                 </TabItem>
 
-            <!-- ── BONUSES TAB ─────────────────────────────────────────────── -->
-            <TabItem Header="Bonuses">
+            <!-- ── BONUSES & BANS TAB ───────────────────────────────────────── -->
+            <TabItem Header="Bonuses &amp; Bans">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <DockPanel Margin="0,8,0,0">
                     <Border DockPanel.Dock="Top" Style="{StaticResource SectionBorder}">
                         <StackPanel>
-                            <DockPanel Margin="0,0,0,6">
-                                <TextBlock DockPanel.Dock="Left"
-                                           Text="◆  GAME START BONUSES"
-                                           Style="{StaticResource SectionHeader}"
-                                           VerticalAlignment="Center"/>
-                                <Button DockPanel.Dock="Right" x:Name="BtnAddBonus"
-                                        Content="+ Add" Width="54" Height="22"
-                                        Click="BtnAddBonus_Click"
-                                        VerticalAlignment="Center"/>
-                            </DockPanel>
+                            <TextBlock Text="◆  GAME START BONUSES"
+                                       Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
                             <TextBlock Text="Bonuses are granted to all players equally at game start."
                                        Foreground="#9A8A6A" FontSize="11"
-                                       Margin="0,0,0,8" TextWrapping="Wrap"/>
-                            <ListBox x:Name="LbBonuses"
-                                     MinHeight="32"
-                                     Background="#2C2619"
-                                     BorderBrush="#5A4A28" BorderThickness="1"
-                                     ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                       Margin="0,0,0,6" TextWrapping="Wrap"/>
+                            <Border Background="#2C2619" BorderBrush="#5A4A28" BorderThickness="1" Margin="0,0,0,0">
+                                <DockPanel>
+                                    <Button DockPanel.Dock="Left" x:Name="BtnAddBonus"
+                                            Content="+" Width="28"
+                                            Click="BtnAddBonus_Click"
+                                            Background="#1E1A10"
+                                            BorderBrush="#7A6A48" BorderThickness="0,0,1,0"
+                                            Foreground="#C8B87A" FontSize="16"
+                                            VerticalAlignment="Stretch"
+                                            Cursor="Hand"/>
+                                    <ListBox x:Name="LbBonuses"
+                                             MinHeight="32"
+                                             Background="Transparent"
+                                             BorderThickness="0"
+                                             ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <ListBox.ItemContainerStyle>
                                     <Style TargetType="ListBoxItem">
                                         <Setter Property="Padding"    Value="0"/>
@@ -647,10 +528,145 @@
                                         </DockPanel>
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>
-                            </ListBox>
+                                    </ListBox>
+                                </DockPanel>
+                            </Border>
+
+                            <Separator Margin="0,12,0,8"/>
+                            <TextBlock Text="◆  BANS &amp; OVERRIDES" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+
+                            <!-- Banned Items -->
+                            <TextBlock Text="Banned items"
+                                       Foreground="#E8D5A3" FontSize="12" Margin="0,0,0,4"/>
+                            <Border Background="#2C2619" BorderBrush="#5A4A28" BorderThickness="1" Margin="0,0,0,10">
+                                <DockPanel>
+                                    <Button DockPanel.Dock="Left" x:Name="BtnAddBannedItem"
+                                            Content="+" Width="28"
+                                            Click="BtnAddBannedItem_Click"
+                                            Background="#1E1A10"
+                                            BorderBrush="#7A6A48" BorderThickness="0,0,1,0"
+                                            Foreground="#C8B87A" FontSize="16"
+                                            VerticalAlignment="Stretch"
+                                            Cursor="Hand"/>
+                                    <ListBox x:Name="LbBannedItems"
+                                             MinHeight="32" MaxHeight="130"
+                                             Background="Transparent"
+                                             BorderThickness="0"
+                                             ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                <ListBox.ItemContainerStyle>
+                                    <Style TargetType="ListBoxItem">
+                                        <Setter Property="Padding"    Value="0"/>
+                                        <Setter Property="Margin"     Value="0"/>
+                                        <Setter Property="Background" Value="Transparent"/>
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate TargetType="ListBoxItem">
+                                                    <ContentPresenter/>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </Style>
+                                </ListBox.ItemContainerStyle>
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <DockPanel Margin="4,2">
+                                            <Button DockPanel.Dock="Right"
+                                                    Content="×" Width="20" Height="18"
+                                                    FontSize="13" Padding="0"
+                                                    Tag="{Binding Id}"
+                                                    Click="RemoveBannedItem_Click"
+                                                    ToolTip="Remove"
+                                                    Background="#3A2820"
+                                                    BorderBrush="#5A4A28"
+                                                    Foreground="#E8D5A3"/>
+                                            <Ellipse Width="8" Height="8"
+                                                     Fill="{Binding CategoryBrush}"
+                                                     VerticalAlignment="Center"
+                                                     Margin="0,0,6,0"/>
+                                            <TextBlock Text="{Binding DisplayName}"
+                                                       Foreground="#E8D5A3" FontSize="12"
+                                                       VerticalAlignment="Center"/>
+                                            <TextBlock Text="{Binding Category}"
+                                                       Foreground="#9A8A6A" FontSize="11"
+                                                       VerticalAlignment="Center"
+                                                       Margin="6,0,0,0"/>
+                                        </DockPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                                    </ListBox>
+                                </DockPanel>
+                            </Border>
+
+                            <!-- Banned Spells -->
+                            <TextBlock Text="Banned spells"
+                                       Foreground="#E8D5A3" FontSize="12" Margin="0,0,0,4"/>
+                            <Border Background="#2C2619" BorderBrush="#5A4A28" BorderThickness="1" Margin="0,0,0,10">
+                                <DockPanel>
+                                    <Button DockPanel.Dock="Left" x:Name="BtnAddBannedMagic"
+                                            Content="+" Width="28"
+                                            Click="BtnAddBannedMagic_Click"
+                                            Background="#1E1A10"
+                                            BorderBrush="#7A6A48" BorderThickness="0,0,1,0"
+                                            Foreground="#C8B87A" FontSize="16"
+                                            VerticalAlignment="Stretch"
+                                            Cursor="Hand"/>
+                                    <ListBox x:Name="LbBannedMagics"
+                                             MinHeight="32" MaxHeight="130"
+                                             Background="Transparent"
+                                             BorderThickness="0"
+                                             ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                <ListBox.ItemContainerStyle>
+                                    <Style TargetType="ListBoxItem">
+                                        <Setter Property="Padding"    Value="0"/>
+                                        <Setter Property="Margin"     Value="0"/>
+                                        <Setter Property="Background" Value="Transparent"/>
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate TargetType="ListBoxItem">
+                                                    <ContentPresenter/>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </Style>
+                                </ListBox.ItemContainerStyle>
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <DockPanel Margin="4,2">
+                                            <Button DockPanel.Dock="Right"
+                                                    Content="×" Width="20" Height="18"
+                                                    FontSize="13" Padding="0"
+                                                    Tag="{Binding Id}"
+                                                    Click="RemoveBannedMagic_Click"
+                                                    ToolTip="Remove"
+                                                    Background="#3A2820"
+                                                    BorderBrush="#5A4A28"
+                                                    Foreground="#E8D5A3"/>
+                                            <Ellipse Width="8" Height="8"
+                                                     Fill="{Binding CategoryBrush}"
+                                                     VerticalAlignment="Center"
+                                                     Margin="0,0,6,0"/>
+                                            <TextBlock Text="{Binding DisplayName}"
+                                                       Foreground="#E8D5A3" FontSize="12"
+                                                       VerticalAlignment="Center"/>
+                                        </DockPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                                    </ListBox>
+                                </DockPanel>
+                            </Border>
+
+                            <!-- Value overrides (kept as free-text) -->
+                            <Label Content="Value overrides (one per line: sid=guardValue)" Padding="0,0,0,2"
+                                   Foreground="#E8D5A3" FontSize="12"/>
+                            <TextBox x:Name="TxtValueOverrides"
+                                     AcceptsReturn="True" Height="68" TextWrapping="NoWrap"
+                                     VerticalScrollBarVisibility="Auto"
+                                     FontFamily="Consolas" FontSize="11"
+                                     TextChanged="BansOverrides_TextChanged"/>
                         </StackPanel>
                     </Border>
                 </DockPanel>
+                </ScrollViewer>
             </TabItem>
 
             <TabItem Header="Layout &amp; Zones">

--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -583,6 +583,76 @@
                     </Grid>
                 </TabItem>
 
+            <!-- ── BONUSES TAB ─────────────────────────────────────────────── -->
+            <TabItem Header="Bonuses">
+                <DockPanel Margin="0,8,0,0">
+                    <Border DockPanel.Dock="Top" Style="{StaticResource SectionBorder}">
+                        <StackPanel>
+                            <DockPanel Margin="0,0,0,6">
+                                <TextBlock DockPanel.Dock="Left"
+                                           Text="◆  GAME START BONUSES"
+                                           Style="{StaticResource SectionHeader}"
+                                           VerticalAlignment="Center"/>
+                                <Button DockPanel.Dock="Right" x:Name="BtnAddBonus"
+                                        Content="+ Add" Width="54" Height="22"
+                                        Click="BtnAddBonus_Click"
+                                        VerticalAlignment="Center"/>
+                            </DockPanel>
+                            <TextBlock Text="Bonuses are granted to all players equally at game start."
+                                       Foreground="#9A8A6A" FontSize="11"
+                                       Margin="0,0,0,8" TextWrapping="Wrap"/>
+                            <ListBox x:Name="LbBonuses"
+                                     MinHeight="32"
+                                     Background="#2C2619"
+                                     BorderBrush="#5A4A28" BorderThickness="1"
+                                     ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                <ListBox.ItemContainerStyle>
+                                    <Style TargetType="ListBoxItem">
+                                        <Setter Property="Padding"    Value="0"/>
+                                        <Setter Property="Margin"     Value="0"/>
+                                        <Setter Property="Background" Value="Transparent"/>
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate TargetType="ListBoxItem">
+                                                    <ContentPresenter/>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </Style>
+                                </ListBox.ItemContainerStyle>
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <DockPanel Margin="4,2">
+                                            <Button DockPanel.Dock="Right"
+                                                    Content="×" Width="20" Height="18"
+                                                    FontSize="13" Padding="0"
+                                                    Tag="{Binding}"
+                                                    Click="RemoveBonus_Click"
+                                                    ToolTip="Remove"
+                                                    Background="#3A2820"
+                                                    BorderBrush="#5A4A28"
+                                                    Foreground="#E8D5A3"/>
+                                            <Ellipse Width="8" Height="8"
+                                                     Fill="{Binding DotBrush}"
+                                                     VerticalAlignment="Center"
+                                                     Margin="0,0,6,0"/>
+                                            <TextBlock Text="{Binding DisplayName}"
+                                                       Foreground="#E8D5A3" FontSize="12"
+                                                       VerticalAlignment="Center"
+                                                       Margin="0,0,8,0"/>
+                                            <TextBlock Text="{Binding ReceiverLabel}"
+                                                       Foreground="#9A8A6A" FontSize="11"
+                                                       VerticalAlignment="Center"
+                                                       FontStyle="Italic"/>
+                                        </DockPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </StackPanel>
+                    </Border>
+                </DockPanel>
+            </TabItem>
+
             <TabItem Header="Layout &amp; Zones">
             <Grid Margin="0,8,0,0">
                 <Grid.RowDefinitions>

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -2,8 +2,10 @@
 using Olden_Era___Template_Editor.Models;
 using Olden_Era___Template_Editor.Services;
 using OldenEraTemplateEditor.Models;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -33,6 +35,10 @@ namespace Olden_Era___Template_Editor
         // Currently open settings file path (null = unsaved / untitled)
         private string? _currentSettingsPath = null;
         private bool _isDirty = false;
+
+        // Ban lists
+        private readonly ObservableCollection<BanEntry> _bannedItems  = [];
+        private readonly ObservableCollection<BanEntry> _bannedMagics = [];
         private bool _isRefreshingMapSizes = false;
         private string _baseTitle = string.Empty;
 
@@ -72,6 +78,10 @@ namespace Olden_Era___Template_Editor
             UpdateAdvancedZoneSettingsVisibility();
             UpdatePlayerCastleFactionVisibility();
             UpdateBalancedZonePlacementDescVisibility();
+
+            // Wire ban-list ObservableCollections to the ListBoxes.
+            LbBannedItems.ItemsSource  = _bannedItems;
+            LbBannedMagics.ItemsSource = _bannedMagics;
 
             // Fire-and-forget background update check — never blocks the UI.
             _ = CheckForUpdateAsync(version);
@@ -448,6 +458,94 @@ namespace Olden_Era___Template_Editor
             Validate();
         }
 
+        private void BansOverrides_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (!IsInitialized) return;
+            MarkDirty();
+        }
+
+        // ── Ban list picker helpers ───────────────────────────────────────────────
+
+        /// <summary>Builds a BanEntry from an artifact ID using the catalog, or a plain fallback entry.</summary>
+        private static BanEntry ItemEntryFromId(string id)
+        {
+            var known = System.Array.Find(KnownValues.BannableItems, b => b.Id == id);
+            if (known != null)
+                return new BanEntry { Id = id, DisplayName = known.DisplayName, Category = known.Category };
+            return new BanEntry { Id = id, DisplayName = KnownValues.SidToDisplayName(id), Category = "Misc" };
+        }
+
+        /// <summary>Builds a BanEntry from a spell ID using the catalog, or a plain fallback entry.</summary>
+        private static BanEntry MagicEntryFromId(string id)
+        {
+            var known = System.Array.Find(KnownValues.BannableMagics, m => m.Id == id);
+            if (known != null)
+                return new BanEntry { Id = id, DisplayName = known.DisplayName, Category = "Spell" };
+            return new BanEntry { Id = id, DisplayName = KnownValues.SidToDisplayName(id), Category = "Spell" };
+        }
+
+        /// <summary>Reloads an ObservableCollection from a newline-separated string of IDs.</summary>
+        private static void LoadBanList(System.Collections.ObjectModel.ObservableCollection<BanEntry> col,
+                                        string raw, bool isMagics)
+        {
+            col.Clear();
+            if (string.IsNullOrWhiteSpace(raw)) return;
+            foreach (var id in raw.Split('\n'))
+            {
+                var trimmed = id.Trim();
+                if (trimmed.Length == 0) continue;
+                col.Add(isMagics ? MagicEntryFromId(trimmed) : ItemEntryFromId(trimmed));
+            }
+        }
+
+        private void BtnAddBannedItem_Click(object sender, RoutedEventArgs e)
+        {
+            var entries = KnownValues.BannableItems
+                .Select(b => new BanEntry { Id = b.Id, DisplayName = b.DisplayName, Category = b.Category });
+            var picker = new ItemPickerWindow(entries, _bannedItems.Select(b => b.Id), "Add Banned Item") { Owner = this };
+            if (picker.ShowDialog() == true && picker.SelectedId is { } id)
+            {
+                if (!_bannedItems.Any(e => e.Id == id))
+                {
+                    _bannedItems.Add(ItemEntryFromId(id));
+                    MarkDirty();
+                }
+            }
+        }
+
+        private void BtnAddBannedMagic_Click(object sender, RoutedEventArgs e)
+        {
+            var entries = KnownValues.BannableMagics
+                .Select(m => new BanEntry { Id = m.Id, DisplayName = m.DisplayName, Category = "Spell" });
+            var picker = new ItemPickerWindow(entries, _bannedMagics.Select(b => b.Id), "Add Banned Spell") { Owner = this };
+            if (picker.ShowDialog() == true && picker.SelectedId is { } id)
+            {
+                if (!_bannedMagics.Any(e => e.Id == id))
+                {
+                    _bannedMagics.Add(MagicEntryFromId(id));
+                    MarkDirty();
+                }
+            }
+        }
+
+        private void RemoveBannedItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement { Tag: string id })
+            {
+                var entry = _bannedItems.FirstOrDefault(b => b.Id == id);
+                if (entry != null) { _bannedItems.Remove(entry); MarkDirty(); }
+            }
+        }
+
+        private void RemoveBannedMagic_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement { Tag: string id })
+            {
+                var entry = _bannedMagics.FirstOrDefault(b => b.Id == id);
+                if (entry != null) { _bannedMagics.Remove(entry); MarkDirty(); }
+            }
+        }
+
         private void CmbMapSize_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (!IsInitialized || _isRefreshingMapSizes) return;
@@ -725,6 +823,10 @@ namespace Olden_Era___Template_Editor
             TournamentFirstTournamentDay = (int)SldTournamentFirstTournamentDay.Value,
             TournamentInterval = (int)SldTournamentInterval.Value,
             TournamentPointsToWin = (int)SldTournamentPointsToWin.Value,
+            TournamentSaveArmy = ChkTournamentSaveArmy.IsChecked == true,
+            BannedItems        = string.Join("\n", _bannedItems.Select(e => e.Id)),
+            BannedMagics       = string.Join("\n", _bannedMagics.Select(e => e.Id)),
+            ValueOverridesText = TxtValueOverrides.Text,
         };
 
         private void ApplySettings(SettingsFile s)
@@ -785,6 +887,9 @@ namespace Olden_Era___Template_Editor
             SldTournamentInterval.Value = Math.Clamp(s.TournamentInterval, 1, 30);
             SldTournamentPointsToWin.Value = Math.Clamp(s.TournamentPointsToWin, 1, 10);
             ChkTournamentSaveArmy.IsChecked = s.TournamentSaveArmy;
+            LoadBanList(_bannedItems,  s.BannedItems,  isMagics: false);
+            LoadBanList(_bannedMagics, s.BannedMagics, isMagics: true);
+            TxtValueOverrides.Text = s.ValueOverridesText;
             UpdateValueLabels();
             UpdateAdvancedZoneSettingsVisibility();
             UpdatePlayerCastleFactionVisibility();
@@ -1038,7 +1143,10 @@ namespace Olden_Era___Template_Editor
                 Interval = (int)SldTournamentInterval.Value,
                 PointsToWin = (int)SldTournamentPointsToWin.Value,
                 SaveArmy = ChkTournamentSaveArmy.IsChecked == true
-            }
+            },
+            BannedItems        = string.Join("\n", _bannedItems.Select(e => e.Id)),
+            BannedMagics       = string.Join("\n", _bannedMagics.Select(e => e.Id)),
+            ValueOverridesText = TxtValueOverrides.Text,
         };
 
         /// <summary>

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -571,7 +571,7 @@ namespace Olden_Era___Template_Editor
 
         private void BtnAddBonus_Click(object sender, RoutedEventArgs e)
         {
-            var picker = new BonusPickerWindow { Owner = this };
+            var picker = new BonusPickerWindow(_bonuses) { Owner = this };
             if (picker.ShowDialog() == true)
             {
                 foreach (var entry in picker.Results)

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -466,6 +466,27 @@ namespace Olden_Era___Template_Editor
             MarkDirty();
         }
 
+        private void BtnPickValueOverride_Click(object sender, RoutedEventArgs e)
+        {
+            // Collect SIDs already in the text box so the picker hides them
+            var existing = TxtValueOverrides.Text
+                .Split('\n')
+                .Select(l => { var eq = l.IndexOf('='); return eq > 0 ? l[..eq].Trim() : ""; })
+                .Where(s => s.Length > 0)
+                .ToHashSet();
+
+            var picker = new ValueOverridePickerWindow(existing) { Owner = this };
+            if (picker.ShowDialog() == true && picker.ResultLines.Count > 0)
+            {
+                var current = TxtValueOverrides.Text.TrimEnd('\r', '\n');
+                var appended = string.Join("\n", picker.ResultLines);
+                TxtValueOverrides.Text = string.IsNullOrEmpty(current)
+                    ? appended
+                    : current + "\n" + appended;
+                MarkDirty();
+            }
+        }
+
         // ── Ban list picker helpers ───────────────────────────────────────────────
 
         /// <summary>Builds a BanEntry from an artifact ID using the catalog, or a plain fallback entry.</summary>

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -84,7 +84,6 @@ namespace Olden_Era___Template_Editor
             UpdateValueLabels();
             UpdateAdvancedZoneSettingsVisibility();
             UpdatePlayerCastleFactionVisibility();
-            UpdateBalancedZonePlacementDescVisibility();
 
             // Wire ban-list ObservableCollections to the ListBoxes.
             LbBannedItems.ItemsSource  = _bannedItems;

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -505,13 +505,12 @@ namespace Olden_Era___Template_Editor
             var entries = KnownValues.BannableItems
                 .Select(b => new BanEntry { Id = b.Id, DisplayName = b.DisplayName, Category = b.Category });
             var picker = new ItemPickerWindow(entries, _bannedItems.Select(b => b.Id), "Add Banned Item") { Owner = this };
-            if (picker.ShowDialog() == true && picker.SelectedId is { } id)
+            if (picker.ShowDialog() == true)
             {
-                if (!_bannedItems.Any(e => e.Id == id))
-                {
-                    _bannedItems.Add(ItemEntryFromId(id));
-                    MarkDirty();
-                }
+                foreach (var id in picker.SelectedIds)
+                    if (!_bannedItems.Any(e => e.Id == id))
+                        _bannedItems.Add(ItemEntryFromId(id));
+                MarkDirty();
             }
         }
 
@@ -520,13 +519,12 @@ namespace Olden_Era___Template_Editor
             var entries = KnownValues.BannableMagics
                 .Select(m => new BanEntry { Id = m.Id, DisplayName = m.DisplayName, Category = "Spell" });
             var picker = new ItemPickerWindow(entries, _bannedMagics.Select(b => b.Id), "Add Banned Spell") { Owner = this };
-            if (picker.ShowDialog() == true && picker.SelectedId is { } id)
+            if (picker.ShowDialog() == true)
             {
-                if (!_bannedMagics.Any(e => e.Id == id))
-                {
-                    _bannedMagics.Add(MagicEntryFromId(id));
-                    MarkDirty();
-                }
+                foreach (var id in picker.SelectedIds)
+                    if (!_bannedMagics.Any(e => e.Id == id))
+                        _bannedMagics.Add(MagicEntryFromId(id));
+                MarkDirty();
             }
         }
 
@@ -553,9 +551,10 @@ namespace Olden_Era___Template_Editor
         private void BtnAddBonus_Click(object sender, RoutedEventArgs e)
         {
             var picker = new BonusPickerWindow { Owner = this };
-            if (picker.ShowDialog() == true && picker.Result is { } entry)
+            if (picker.ShowDialog() == true)
             {
-                _bonuses.Add(entry);
+                foreach (var entry in picker.Results)
+                    _bonuses.Add(entry);
                 MarkDirty();
             }
         }

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -578,9 +578,9 @@ namespace Olden_Era___Template_Editor
         /// <summary>Builds a BanEntry from a spell ID using the catalog, or a plain fallback entry.</summary>
         private static BanEntry MagicEntryFromId(string id)
         {
-            var known = System.Array.Find(KnownValues.BannableMagics, m => m.Id == id);
+            var known = System.Array.Find(KnownValues.KnownSpells, s => s.Id == id);
             if (known != null)
-                return new BanEntry { Id = id, DisplayName = known.DisplayName, Category = "Spell" };
+                return new BanEntry { Id = id, DisplayName = known.Name, Category = "Spell" };
             return new BanEntry { Id = id, DisplayName = KnownValues.SidToDisplayName(id), Category = "Spell" };
         }
 
@@ -614,9 +614,7 @@ namespace Olden_Era___Template_Editor
 
         private void BtnAddBannedMagic_Click(object sender, RoutedEventArgs e)
         {
-            var entries = KnownValues.BannableMagics
-                .Select(m => new BanEntry { Id = m.Id, DisplayName = m.DisplayName, Category = "Spell" });
-            var picker = new ItemPickerWindow(entries, _bannedMagics.Select(b => b.Id), "Add Banned Spell") { Owner = this };
+            var picker = new SpellPickerWindow(_bannedMagics.Select(b => b.Id), showMakeFree: false) { Owner = this };
             if (picker.ShowDialog() == true)
             {
                 foreach (var id in picker.SelectedIds)

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -37,8 +37,9 @@ namespace Olden_Era___Template_Editor
         private bool _isDirty = false;
 
         // Ban lists
-        private readonly ObservableCollection<BanEntry> _bannedItems  = [];
-        private readonly ObservableCollection<BanEntry> _bannedMagics = [];
+        private readonly ObservableCollection<BanEntry>   _bannedItems  = [];
+        private readonly ObservableCollection<BanEntry>   _bannedMagics = [];
+        private readonly ObservableCollection<BonusEntry> _bonuses      = [];
         private bool _isRefreshingMapSizes = false;
         private string _baseTitle = string.Empty;
 
@@ -82,6 +83,7 @@ namespace Olden_Era___Template_Editor
             // Wire ban-list ObservableCollections to the ListBoxes.
             LbBannedItems.ItemsSource  = _bannedItems;
             LbBannedMagics.ItemsSource = _bannedMagics;
+            LbBonuses.ItemsSource      = _bonuses;
 
             // Fire-and-forget background update check — never blocks the UI.
             _ = CheckForUpdateAsync(version);
@@ -546,6 +548,38 @@ namespace Olden_Era___Template_Editor
             }
         }
 
+        // ── Bonus list handlers ───────────────────────────────────────────────────
+
+        private void BtnAddBonus_Click(object sender, RoutedEventArgs e)
+        {
+            var picker = new BonusPickerWindow { Owner = this };
+            if (picker.ShowDialog() == true && picker.Result is { } entry)
+            {
+                _bonuses.Add(entry);
+                MarkDirty();
+            }
+        }
+
+        private void RemoveBonus_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement { Tag: BonusEntry entry })
+            {
+                _bonuses.Remove(entry);
+                MarkDirty();
+            }
+        }
+
+        private void LoadBonusList(string raw)
+        {
+            _bonuses.Clear();
+            if (string.IsNullOrWhiteSpace(raw)) return;
+            foreach (var line in raw.Split('\n'))
+            {
+                var entry = BonusEntry.FromString(line.Trim());
+                if (entry != null) _bonuses.Add(entry);
+            }
+        }
+
         private void CmbMapSize_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (!IsInitialized || _isRefreshingMapSizes) return;
@@ -827,6 +861,7 @@ namespace Olden_Era___Template_Editor
             BannedItems        = string.Join("\n", _bannedItems.Select(e => e.Id)),
             BannedMagics       = string.Join("\n", _bannedMagics.Select(e => e.Id)),
             ValueOverridesText = TxtValueOverrides.Text,
+            BonusesJson        = string.Join("\n", _bonuses.Select(b => b.ToString())),
         };
 
         private void ApplySettings(SettingsFile s)
@@ -889,6 +924,7 @@ namespace Olden_Era___Template_Editor
             ChkTournamentSaveArmy.IsChecked = s.TournamentSaveArmy;
             LoadBanList(_bannedItems,  s.BannedItems,  isMagics: false);
             LoadBanList(_bannedMagics, s.BannedMagics, isMagics: true);
+            LoadBonusList(s.BonusesJson);
             TxtValueOverrides.Text = s.ValueOverridesText;
             UpdateValueLabels();
             UpdateAdvancedZoneSettingsVisibility();
@@ -1147,6 +1183,7 @@ namespace Olden_Era___Template_Editor
             BannedItems        = string.Join("\n", _bannedItems.Select(e => e.Id)),
             BannedMagics       = string.Join("\n", _bannedMagics.Select(e => e.Id)),
             ValueOverridesText = TxtValueOverrides.Text,
+            Bonuses            = [.. _bonuses],
         };
 
         /// <summary>

--- a/Olden Era - Template Editor/Models/Generator/GeneratorSettings.cs
+++ b/Olden Era - Template Editor/Models/Generator/GeneratorSettings.cs
@@ -82,6 +82,7 @@ namespace Olden_Era___Template_Editor.Models
         public string BannedItems { get; set; } = "";
         public string BannedMagics { get; set; } = "";
         public string ValueOverridesText { get; set; } = "";
+        public System.Collections.Generic.List<OldenEraTemplateEditor.Models.BonusEntry> Bonuses { get; set; } = [];
         public GameEndConditions GameEndConditions { get; set; } = new GameEndConditions();
         public GladiatorArenaRules GladiatorArenaRules { get; set; } = new GladiatorArenaRules();
         public TournamentRules TournamentRules { get; set; } = new TournamentRules();

--- a/Olden Era - Template Editor/Models/Generator/GeneratorSettings.cs
+++ b/Olden Era - Template Editor/Models/Generator/GeneratorSettings.cs
@@ -79,6 +79,9 @@ namespace Olden_Era___Template_Editor.Models
         public ZoneConfiguration ZoneCfg { get; set; } = new ZoneConfiguration();
         public int FactionLawsExpPercent { get; set; } = 100;
         public int AstrologyExpPercent { get; set; } = 100;
+        public string BannedItems { get; set; } = "";
+        public string BannedMagics { get; set; } = "";
+        public string ValueOverridesText { get; set; } = "";
         public GameEndConditions GameEndConditions { get; set; } = new GameEndConditions();
         public GladiatorArenaRules GladiatorArenaRules { get; set; } = new GladiatorArenaRules();
         public TournamentRules TournamentRules { get; set; } = new TournamentRules();

--- a/Olden Era - Template Editor/Models/Generator/SettingsFile.cs
+++ b/Olden Era - Template Editor/Models/Generator/SettingsFile.cs
@@ -62,7 +62,7 @@ namespace Olden_Era___Template_Editor.Models
         [JsonPropertyName("bannedItems")]        public string BannedItems                  { get; set; } = "";
         [JsonPropertyName("bannedMagics")]       public string BannedMagics                 { get; set; } = "";
         [JsonPropertyName("valueOverrides")]     public string ValueOverridesText           { get; set; } = "";
-        [JsonPropertyName("bonuses")]            public string BonusesSerialized            { get; set; } = "";
+        [JsonPropertyName("bonuses")]            public string BonusesJson                  { get; set; } = "";
         // Legacy setting from v0.2 and earlier; when present, it seeds both split density sliders.
         [JsonPropertyName("contentDensity")]    public int?    ContentDensityPercent        { get; set; }
 

--- a/Olden Era - Template Editor/Models/Generator/SettingsFile.cs
+++ b/Olden Era - Template Editor/Models/Generator/SettingsFile.cs
@@ -59,6 +59,9 @@ namespace Olden_Era___Template_Editor.Models
         [JsonPropertyName("tournamentInterval")] public int TournamentInterval    { get; set; } = 7;
         [JsonPropertyName("tournamentPointsToWin")] public int TournamentPointsToWin        { get; set; } = 2;
         [JsonPropertyName("tournamentSaveArmy")] public bool TournamentSaveArmy             { get; set; } = true;
+        [JsonPropertyName("bannedItems")]        public string BannedItems                  { get; set; } = "";
+        [JsonPropertyName("bannedMagics")]       public string BannedMagics                 { get; set; } = "";
+        [JsonPropertyName("valueOverrides")]     public string ValueOverridesText           { get; set; } = "";
 
         // Legacy setting from v0.2 and earlier; when present, it seeds both split density sliders.
         [JsonPropertyName("contentDensity")]    public int?    ContentDensityPercent        { get; set; }

--- a/Olden Era - Template Editor/Models/Generator/SettingsFile.cs
+++ b/Olden Era - Template Editor/Models/Generator/SettingsFile.cs
@@ -61,7 +61,8 @@ namespace Olden_Era___Template_Editor.Models
         [JsonPropertyName("tournamentSaveArmy")] public bool TournamentSaveArmy             { get; set; } = true;
         [JsonPropertyName("bannedItems")]        public string BannedItems                  { get; set; } = "";
         [JsonPropertyName("bannedMagics")]       public string BannedMagics                 { get; set; } = "";
-        [JsonPropertyName("valueOverrides")]     public string ValueOverridesText           { get; set; } = "";        [JsonPropertyName("bonuses")]            public string BonusesJson                  { get; set; } = "";
+        [JsonPropertyName("valueOverrides")]     public string ValueOverridesText           { get; set; } = "";
+        [JsonPropertyName("bonuses")]            public string BonusesSerialized            { get; set; } = "";
         // Legacy setting from v0.2 and earlier; when present, it seeds both split density sliders.
         [JsonPropertyName("contentDensity")]    public int?    ContentDensityPercent        { get; set; }
 

--- a/Olden Era - Template Editor/Models/Generator/SettingsFile.cs
+++ b/Olden Era - Template Editor/Models/Generator/SettingsFile.cs
@@ -61,8 +61,7 @@ namespace Olden_Era___Template_Editor.Models
         [JsonPropertyName("tournamentSaveArmy")] public bool TournamentSaveArmy             { get; set; } = true;
         [JsonPropertyName("bannedItems")]        public string BannedItems                  { get; set; } = "";
         [JsonPropertyName("bannedMagics")]       public string BannedMagics                 { get; set; } = "";
-        [JsonPropertyName("valueOverrides")]     public string ValueOverridesText           { get; set; } = "";
-
+        [JsonPropertyName("valueOverrides")]     public string ValueOverridesText           { get; set; } = "";        [JsonPropertyName("bonuses")]            public string BonusesJson                  { get; set; } = "";
         // Legacy setting from v0.2 and earlier; when present, it seeds both split density sliders.
         [JsonPropertyName("contentDensity")]    public int?    ContentDensityPercent        { get; set; }
 

--- a/Olden Era - Template Editor/Models/Unfrozen/BanEntry.cs
+++ b/Olden Era - Template Editor/Models/Unfrozen/BanEntry.cs
@@ -1,0 +1,25 @@
+using System.Windows.Media;
+
+namespace OldenEraTemplateEditor.Models
+{
+    /// <summary>
+    /// UI view-model for a single row in the banned-items or banned-spells ListBox.
+    /// </summary>
+    public class BanEntry
+    {
+        public string Id          { get; set; } = "";
+        public string DisplayName { get; set; } = "";
+        public string Category    { get; set; } = "";
+
+        public Brush CategoryBrush => Category switch
+        {
+            "Movement"  => new SolidColorBrush(Color.FromRgb(100, 149, 237)), // cornflower blue
+            "Diplomacy" => new SolidColorBrush(Color.FromRgb(218, 165,  32)), // goldenrod
+            "Combat"    => new SolidColorBrush(Color.FromRgb(205,  92,  92)), // indian red
+            "Magic"     => new SolidColorBrush(Color.FromRgb(147, 112, 219)), // medium purple
+            "Set"       => new SolidColorBrush(Color.FromRgb(186,  85, 211)), // medium orchid
+            "Spell"     => new SolidColorBrush(Color.FromRgb(147, 112, 219)), // medium purple
+            _           => new SolidColorBrush(Color.FromRgb(150, 150, 150)), // gray
+        };
+    }
+}

--- a/Olden Era - Template Editor/Models/Unfrozen/BanEntry.cs
+++ b/Olden Era - Template Editor/Models/Unfrozen/BanEntry.cs
@@ -7,19 +7,33 @@ namespace OldenEraTemplateEditor.Models
     /// </summary>
     public class BanEntry
     {
+        private static readonly Brush MovementCategoryBrush  = CreateFrozenBrush(Color.FromRgb(100, 149, 237)); // cornflower blue
+        private static readonly Brush DiplomacyCategoryBrush = CreateFrozenBrush(Color.FromRgb(218, 165,  32)); // goldenrod
+        private static readonly Brush CombatCategoryBrush    = CreateFrozenBrush(Color.FromRgb(205,  92,  92)); // indian red
+        private static readonly Brush MagicCategoryBrush     = CreateFrozenBrush(Color.FromRgb(147, 112, 219)); // medium purple
+        private static readonly Brush SetCategoryBrush       = CreateFrozenBrush(Color.FromRgb(186,  85, 211)); // medium orchid
+        private static readonly Brush DefaultCategoryBrush   = CreateFrozenBrush(Color.FromRgb(150, 150, 150)); // gray
+
+        private static Brush CreateFrozenBrush(Color color)
+        {
+            var brush = new SolidColorBrush(color);
+            brush.Freeze();
+            return brush;
+        }
+
         public string Id          { get; set; } = "";
         public string DisplayName { get; set; } = "";
         public string Category    { get; set; } = "";
 
         public Brush CategoryBrush => Category switch
         {
-            "Movement"  => new SolidColorBrush(Color.FromRgb(100, 149, 237)), // cornflower blue
-            "Diplomacy" => new SolidColorBrush(Color.FromRgb(218, 165,  32)), // goldenrod
-            "Combat"    => new SolidColorBrush(Color.FromRgb(205,  92,  92)), // indian red
-            "Magic"     => new SolidColorBrush(Color.FromRgb(147, 112, 219)), // medium purple
-            "Set"       => new SolidColorBrush(Color.FromRgb(186,  85, 211)), // medium orchid
-            "Spell"     => new SolidColorBrush(Color.FromRgb(147, 112, 219)), // medium purple
-            _           => new SolidColorBrush(Color.FromRgb(150, 150, 150)), // gray
+            "Movement"  => MovementCategoryBrush,
+            "Diplomacy" => DiplomacyCategoryBrush,
+            "Combat"    => CombatCategoryBrush,
+            "Magic"     => MagicCategoryBrush,
+            "Set"       => SetCategoryBrush,
+            "Spell"     => MagicCategoryBrush,
+            _           => DefaultCategoryBrush,
         };
     }
 }

--- a/Olden Era - Template Editor/Models/Unfrozen/BonusEntry.cs
+++ b/Olden Era - Template Editor/Models/Unfrozen/BonusEntry.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Windows.Media;
+
+namespace OldenEraTemplateEditor.Models
+{
+    public enum BonusPresetType
+    {
+        TownPortalFree   = 0,
+        Spell            = 1,
+        UnitMultiplier   = 2,
+        MovementBonus    = 3,
+        StartingItem     = 4,
+        StartingGold     = 5,
+        StartingGems     = 6,
+        StartingCrystals = 7,
+        StartingMercury  = 8,
+    }
+
+    /// <summary>UI view-model for a single configurable game-start bonus.</summary>
+    public class BonusEntry
+    {
+        public BonusPresetType PresetType     { get; set; } = BonusPresetType.TownPortalFree;
+        /// <summary>"start_hero" or "all_heroes"</summary>
+        public string          ReceiverFilter { get; set; } = "start_hero";
+        /// <summary>Spell sid / item sid / numeric value depending on type.</summary>
+        public string          Param          { get; set; } = "";
+        /// <summary>For Spell: "1" = free, "0" = normal. Unused for other types.</summary>
+        public string          Param2         { get; set; } = "0";
+
+        public string ReceiverLabel  => ReceiverFilter == "start_hero" ? "start hero" : "all heroes";
+
+        public string DisplayName => PresetType switch
+        {
+            BonusPresetType.TownPortalFree                  => "Town Portal (free)",
+            BonusPresetType.Spell when Param2 == "1"        => $"Spell (free): {SpellLabel(Param)}",
+            BonusPresetType.Spell                           => $"Spell: {SpellLabel(Param)}",
+            BonusPresetType.UnitMultiplier                  => $"Unit multiplier ×{Param}",
+            BonusPresetType.MovementBonus                   => $"Movement bonus +{Param}",
+            BonusPresetType.StartingItem                    => $"Starting item: {Param}",
+            BonusPresetType.StartingGold                    => $"Starting gold: {Param}",
+            BonusPresetType.StartingGems                    => $"Starting gems: {Param}",
+            BonusPresetType.StartingCrystals                => $"Starting crystals: {Param}",
+            BonusPresetType.StartingMercury                 => $"Starting mercury: {Param}",
+            _                                               => PresetType.ToString(),
+        };
+
+        private static string SpellLabel(string sid) => sid switch
+        {
+            "neutral_magic_town_portal"      => "Town Portal",
+            "neutral_magic_dimension_door"   => "Dimension Door",
+            "neutral_magic_shadow_form"      => "Shadow Form",
+            "neutral_magic_light_gate"       => "Light Gate",
+            "neutral_magic_pocket_dimension" => "Pocket Dimension",
+            _ => sid,
+        };
+
+        public Brush DotBrush => PresetType switch
+        {
+            BonusPresetType.TownPortalFree or BonusPresetType.Spell
+                => new SolidColorBrush(Color.FromRgb(147, 112, 219)), // medium purple (magic)
+            BonusPresetType.UnitMultiplier
+                => new SolidColorBrush(Color.FromRgb(205,  92,  92)), // indian red (combat)
+            BonusPresetType.MovementBonus
+                => new SolidColorBrush(Color.FromRgb(100, 149, 237)), // cornflower blue (movement)
+            BonusPresetType.StartingItem
+                => new SolidColorBrush(Color.FromRgb(186,  85, 211)), // medium orchid (set)
+            _ /* resources */
+                => new SolidColorBrush(Color.FromRgb(218, 165,  32)), // goldenrod (resources)
+        };
+
+        /// <summary>Expands this entry into one or two raw Bonus objects for the template.</summary>
+        public List<Bonus> ToBonuses()
+        {
+            var list = new List<Bonus>();
+            switch (PresetType)
+            {
+                case BonusPresetType.TownPortalFree:
+                    list.Add(new Bonus { Sid = "add_bonus_hero_spell", ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = ["neutral_magic_town_portal"] });
+                    list.Add(new Bonus { Sid = "add_bonus_hero_stat",  ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = ["magicCostSidSet", "neutral_magic_town_portal", "-999", "0"] });
+                    break;
+                case BonusPresetType.Spell:
+                    list.Add(new Bonus { Sid = "add_bonus_hero_spell", ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = [Param] });
+                    if (Param2 == "1")
+                        list.Add(new Bonus { Sid = "add_bonus_hero_stat", ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = ["magicCostSidSet", Param, "-999", "0"] });
+                    break;
+                case BonusPresetType.UnitMultiplier:
+                    list.Add(new Bonus { Sid = "add_bonus_hero_unit_multipler", ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = [Param] });
+                    break;
+                case BonusPresetType.MovementBonus:
+                    list.Add(new Bonus { Sid = "add_bonus_hero_stat", ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = ["movementBonus", Param] });
+                    break;
+                case BonusPresetType.StartingItem:
+                    list.Add(new Bonus { Sid = "add_bonus_hero_item", ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = [Param] });
+                    break;
+                case BonusPresetType.StartingGold:
+                    list.Add(new Bonus { Sid = "add_bonus_res", ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = ["gold",      Param] });
+                    break;
+                case BonusPresetType.StartingGems:
+                    list.Add(new Bonus { Sid = "add_bonus_res", ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = ["gemstones", Param] });
+                    break;
+                case BonusPresetType.StartingCrystals:
+                    list.Add(new Bonus { Sid = "add_bonus_res", ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = ["crystals",  Param] });
+                    break;
+                case BonusPresetType.StartingMercury:
+                    list.Add(new Bonus { Sid = "add_bonus_res", ReceiverSide = -1, ReceiverFilter = ReceiverFilter, Parameters = ["mercury",   Param] });
+                    break;
+            }
+            return list;
+        }
+
+        // ── Serialization ─────────────────────────────────────────────────────────
+
+        /// <summary>Serializes to a compact pipe-separated string for storage.</summary>
+        public override string ToString() =>
+            $"{(int)PresetType}|{ReceiverFilter}|{Param}|{Param2}";
+
+        /// <summary>Deserializes from a pipe-separated string produced by <see cref="ToString"/>.</summary>
+        public static BonusEntry? FromString(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return null;
+            var p = s.Split('|');
+            if (p.Length < 4 || !int.TryParse(p[0], out int t)) return null;
+            return new BonusEntry
+            {
+                PresetType     = (BonusPresetType)t,
+                ReceiverFilter = p[1],
+                Param          = p[2],
+                Param2         = p[3],
+            };
+        }
+    }
+}

--- a/Olden Era - Template Editor/Models/Unfrozen/BonusEntry.cs
+++ b/Olden Era - Template Editor/Models/Unfrozen/BonusEntry.cs
@@ -44,15 +44,11 @@ namespace OldenEraTemplateEditor.Models
             _                                               => PresetType.ToString(),
         };
 
-        private static string SpellLabel(string sid) => sid switch
+        private static string SpellLabel(string sid)
         {
-            "neutral_magic_town_portal"      => "Town Portal",
-            "neutral_magic_dimension_door"   => "Dimension Door",
-            "neutral_magic_shadow_form"      => "Shadow Form",
-            "neutral_magic_light_gate"       => "Light Gate",
-            "neutral_magic_pocket_dimension" => "Pocket Dimension",
-            _ => sid,
-        };
+            var known = System.Array.Find(KnownValues.KnownSpells, s => s.Id == sid);
+            return known?.Name ?? sid;
+        }
 
         private static readonly Brush MagicDotBrush    = CreateFrozenBrush(Color.FromRgb(147, 112, 219));
         private static readonly Brush CombatDotBrush   = CreateFrozenBrush(Color.FromRgb(205,  92,  92));

--- a/Olden Era - Template Editor/Models/Unfrozen/BonusEntry.cs
+++ b/Olden Era - Template Editor/Models/Unfrozen/BonusEntry.cs
@@ -54,18 +54,31 @@ namespace OldenEraTemplateEditor.Models
             _ => sid,
         };
 
+        private static readonly Brush MagicDotBrush    = CreateFrozenBrush(Color.FromRgb(147, 112, 219));
+        private static readonly Brush CombatDotBrush   = CreateFrozenBrush(Color.FromRgb(205,  92,  92));
+        private static readonly Brush MovementDotBrush = CreateFrozenBrush(Color.FromRgb(100, 149, 237));
+        private static readonly Brush SetDotBrush      = CreateFrozenBrush(Color.FromRgb(186,  85, 211));
+        private static readonly Brush ResourceDotBrush = CreateFrozenBrush(Color.FromRgb(218, 165,  32));
+
+        private static Brush CreateFrozenBrush(Color color)
+        {
+            var brush = new SolidColorBrush(color);
+            brush.Freeze();
+            return brush;
+        }
+
         public Brush DotBrush => PresetType switch
         {
             BonusPresetType.TownPortalFree or BonusPresetType.Spell
-                => new SolidColorBrush(Color.FromRgb(147, 112, 219)), // medium purple (magic)
+                => MagicDotBrush,    // medium purple (magic)
             BonusPresetType.UnitMultiplier
-                => new SolidColorBrush(Color.FromRgb(205,  92,  92)), // indian red (combat)
+                => CombatDotBrush,   // indian red (combat)
             BonusPresetType.MovementBonus
-                => new SolidColorBrush(Color.FromRgb(100, 149, 237)), // cornflower blue (movement)
+                => MovementDotBrush, // cornflower blue (movement)
             BonusPresetType.StartingItem
-                => new SolidColorBrush(Color.FromRgb(186,  85, 211)), // medium orchid (set)
+                => SetDotBrush,      // medium orchid (set)
             _ /* resources */
-                => new SolidColorBrush(Color.FromRgb(218, 165,  32)), // goldenrod (resources)
+                => ResourceDotBrush, // goldenrod (resources)
         };
 
         /// <summary>Expands this entry into one or two raw Bonus objects for the template.</summary>

--- a/Olden Era - Template Editor/Models/Unfrozen/KnownValues.cs
+++ b/Olden Era - Template Editor/Models/Unfrozen/KnownValues.cs
@@ -323,5 +323,259 @@ namespace OldenEraTemplateEditor.Models
         [
             "Center",
         ];
+
+        // ── Bannable items catalog ────────────────────────────────────────────────
+
+        /// <summary>
+        /// Record for an artifact that can appear in globalBans.items.
+        /// Category is one of: Movement, Diplomacy, Combat.
+        /// Extend this list as new artifacts are added to the game.
+        /// </summary>
+        public record BannableItem(string Id, string DisplayName, string Category);
+
+        /// <summary>
+        /// Record for a spell that can appear in globalBans.magics.
+        /// Extend this list as new spells are added to the game.
+        /// </summary>
+        public record BannableMagic(string Id, string DisplayName);
+
+        /// <summary>Known bannable artifact IDs sourced from official game templates and test_content_lists.</summary>
+        public static readonly BannableItem[] BannableItems =
+        [
+            // ── Movement ──────────────────────────────────────────────────────────
+            new("pole_star_artifact",                                              "Pole Star",                                        "Movement"),
+            new("seven_league_boots_artifact",                                     "Seven League Boots",                               "Movement"),
+            new("swamp_boots_artifact",                                            "Swamp Boots",                                      "Movement"),
+            new("warlord_boots_artifact",                                          "Warlord Boots",                                    "Movement"),
+            new("magic_key_ring_artifact",                                         "Magic Key Ring",                                   "Movement"),
+            new("legions_step_artifact",                                           "Legion's Step",                                    "Movement"),
+            new("fallen_angel_wings_artifact",                                     "Fallen Angel Wings",                               "Movement"),
+            new("banner_of_four_winds_artifact",                                   "Banner of Four Winds",                             "Movement"),
+            new("spyglass_artifact",                                               "Spyglass",                                         "Movement"),
+
+            // ── Diplomacy ─────────────────────────────────────────────────────────
+            new("voodoosh_doll_artifact",                                          "Voodoosh Doll",                                    "Diplomacy"),
+            new("flag_of_truce_artifact",                                          "Flag of Truce",                                    "Diplomacy"),
+            new("ring_of_neutrality_artifact",                                     "Ring of Neutrality",                               "Diplomacy"),
+
+            // ── Combat ───────────────────────────────────────────────────────────
+            new("shackles_of_war_artifact",                                        "Shackles of War",                                  "Combat"),
+            new("ogres_club_of_havoc_artifact",                                    "Ogre's Club of Havoc",                             "Combat"),
+            new("tarq_of_the_rampaging_ogre_artifact",                             "Tarq of the Rampaging Ogre",                       "Combat"),
+            new("tunic_of_the_cyclops_king_artifact",                              "Tunic of the Cyclops King",                        "Combat"),
+            new("garotte_artifact",                                                "Garotte",                                          "Combat"),
+            new("hourglass_of_protection_artifact",                                "Hourglass of Protection",                          "Combat"),
+            new("shoddy_shield_artifact",                                          "Shoddy Shield",                                    "Combat"),
+            new("eagle_armor_artifact",                                            "Eagle Armor",                                      "Combat"),
+            new("chain_mail_artifact",                                             "Chain Mail",                                       "Combat"),
+            new("head_torch_artifact",                                             "Head Torch",                                       "Combat"),
+            new("fine_wand_artifact",                                              "Fine Wand",                                        "Combat"),
+            new("lords_ring_artifact",                                             "Lord's Ring",                                      "Combat"),
+
+            // ── Magic ────────────────────────────────────────────────────────────
+            new("catechism_of_night_magic_artifact",                               "Catechism of Night Magic",                         "Magic"),
+            new("catechism_of_daylight_magic_artifact",                            "Catechism of Daylight Magic",                      "Magic"),
+            new("catechism_of_spacetime_magic_artifact",                           "Catechism of Spacetime Magic",                     "Magic"),
+            new("catechism_of_primal_magic_artifact",                              "Catechism of Primal Magic",                        "Magic"),
+            new("spellbinders_hat_artifact",                                       "Spellbinder's Hat",                                "Magic"),
+            new("spells_in_a_bottle_artifact",                                     "Spells in a Bottle",                               "Magic"),
+            new("orb_of_inhibition_artifact",                                      "Orb of Inhibition",                                "Magic"),
+            new("orb_of_destruction_artifact",                                     "Orb of Destruction",                               "Magic"),
+            new("seal_of_silence_artifact",                                        "Seal of Silence",                                  "Magic"),
+            new("crown_of_the_supreme_magi_artifact",                              "Crown of the Supreme Magi",                        "Magic"),
+            new("clothes_of_enlightenment_artifact",                               "Clothes of Enlightenment",                         "Magic"),
+            new("cards_deck_artifact",                                             "Cards Deck",                                       "Magic"),
+            new("runestone_shards_artifact",                                       "Runestone Shards",                                 "Magic"),
+
+            // ── Misc (standalone) ────────────────────────────────────────────────
+            new("golden_goose_egg_artifact",                                       "Golden Goose Egg",                                 "Misc"),
+            new("tactical_guide_artifact",                                         "Tactical Guide",                                   "Misc"),
+            new("endless_bag_artifact",                                            "Endless Bag",                                      "Misc"),
+            new("soulless_sash_artifact",                                          "Soulless Sash",                                    "Misc"),
+            new("monster_head_artifact",                                           "Monster Head",                                     "Misc"),
+            new("omencaller_artifact",                                             "Omencaller",                                       "Misc"),
+            new("sixth_finger_artifact",                                           "Sixth Finger",                                     "Misc"),
+            new("soulscaller_ring_artifact",                                       "Soulscaller Ring",                                 "Misc"),
+            new("chain_link_artifact",                                             "Chain Link",                                       "Misc"),
+            new("demonic_heart_artifact",                                          "Demonic Heart",                                    "Misc"),
+            new("two_faced_mask_artifact",                                         "Two-Faced Mask",                                   "Misc"),
+            new("ancient_idol_artifact",                                           "Ancient Idol",                                     "Misc"),
+            new("excalibur_artifact",                                              "Excalibur",                                        "Misc"),
+            new("caduceus_artifact",                                               "Caduceus",                                         "Misc"),
+
+            // ── Set: Resonant Sphere ──────────────────────────────────────────────
+            new("resonant_sphere_orb_of_twilight_artifact",                        "Resonant Sphere: Orb of Twilight",                 "Set"),
+            new("resonant_sphere_orb_of_daylight_artifact",                        "Resonant Sphere: Orb of Daylight",                 "Set"),
+            new("resonant_sphere_orb_of_eternity_artifact",                        "Resonant Sphere: Orb of Eternity",                 "Set"),
+            new("resonant_sphere_primal_orb_artifact",                             "Resonant Sphere: Primal Orb",                      "Set"),
+
+            // ── Set: Tranquility ──────────────────────────────────────────────────
+            new("tranquility_brightmind_tiara_artifact",                           "Tranquility: Brightmind Tiara",                    "Set"),
+            new("tranquility_magic_mirror_artifact",                               "Tranquility: Magic Mirror",                        "Set"),
+            new("tranquility_ring_of_serenity_artifact",                           "Tranquility: Ring of Serenity",                    "Set"),
+
+            // ── Set: Shamaniac Soul ───────────────────────────────────────────────
+            new("shamaniac_soul_shaman_staff_artifact",                            "Shamaniac Soul: Shaman Staff",                     "Set"),
+            new("shamaniac_soul_iridescent_cloak_artifact",                        "Shamaniac Soul: Iridescent Cloak",                 "Set"),
+            new("shamaniac_soul_gemwood_mask_artifact",                            "Shamaniac Soul: Gemwood Mask",                     "Set"),
+            new("shamaniac_soul_clutching_ring_artifact",                          "Shamaniac Soul: Clutching Ring",                   "Set"),
+
+            // ── Set: Knight's Honor ───────────────────────────────────────────────
+            new("knights_honor_drums_of_war_artifact",                             "Knight's Honor: Drums of War",                     "Set"),
+            new("knights_honor_lance_artifact",                                    "Knight's Honor: Lance",                            "Set"),
+            new("knights_honor_misericorde_artifact",                              "Knight's Honor: Misericorde",                      "Set"),
+            new("knights_honor_plate_armor_artifact",                              "Knight's Honor: Plate Armor",                      "Set"),
+            new("knights_honor_armet_artifact",                                    "Knight's Honor: Armet",                            "Set"),
+
+            // ── Set: Ukhtabar Seal ────────────────────────────────────────────────
+            new("ukhtabar_seal_ukh_seal_artifact",                                 "Ukhtabar Seal: Ukh Seal",                          "Set"),
+            new("ukhtabar_seal_tabar_seal_artifact",                               "Ukhtabar Seal: Tabar Seal",                        "Set"),
+
+            // ── Set: Milo's Curse ─────────────────────────────────────────────────
+            new("milos_curse_golden_pig_artifact",                                 "Milo's Curse: Golden Pig",                         "Set"),
+            new("milos_curse_golden_moth_artifact",                                "Milo's Curse: Golden Moth",                        "Set"),
+            new("milos_curse_skull_of_milos_artifact",                             "Milo's Curse: Skull of Milos",                     "Set"),
+
+            // ── Set: Pauper's Glory ───────────────────────────────────────────────
+            new("paupers_glory_wooden_ring_artifact",                              "Pauper's Glory: Wooden Ring",                      "Set"),
+            new("paupers_glory_straw_hat_artifact",                                "Pauper's Glory: Straw Hat",                        "Set"),
+            new("paupers_glory_rope_belt_artifact",                                "Pauper's Glory: Rope Belt",                        "Set"),
+            new("paupers_glory_rags_artifact",                                     "Pauper's Glory: Rags",                             "Set"),
+            new("paupers_glory_dumb_club_artifact",                                "Pauper's Glory: Dumb Club",                        "Set"),
+            new("paupers_glory_last_coin_artifact",                                "Pauper's Glory: Last Coin",                        "Set"),
+
+            // ── Set: Angelic Alliance ─────────────────────────────────────────────
+            new("angelic_alliance_sword_of_judgement_artifact",                    "Angelic Alliance: Sword of Judgement",             "Set"),
+            new("angelic_alliance_celestial_sash_of_bliss_artifact",               "Angelic Alliance: Celestial Sash of Bliss",        "Set"),
+            new("angelic_alliance_lions_shield_of_courage_artifact",               "Angelic Alliance: Lion's Shield of Courage",       "Set"),
+            new("angelic_alliance_armor_of_wonder_artifact",                       "Angelic Alliance: Armor of Wonder",                "Set"),
+            new("angelic_alliance_helm_of_heavenly_enlightenment_artifact",        "Angelic Alliance: Helm of Heavenly Enlightenment", "Set"),
+            new("angelic_alliance_sandals_of_the_saint_artifact",                  "Angelic Alliance: Sandals of the Saint",           "Set"),
+
+            // ── Set: Gifts of Dwarven Lords ───────────────────────────────────────
+            new("gifts_of_dwarven_lords_automated_antimagic_shield_artifact",      "Dwarven Gifts: Automated Antimagic Shield",        "Set"),
+            new("gifts_of_dwarven_lords_automated_antimagic_shield_artifact_alt",  "Dwarven Gifts: Automated Antimagic Shield (Alt)",  "Set"),
+            new("gifts_of_dwarven_lords_protective_belt_artifact",                 "Dwarven Gifts: Protective Belt",                   "Set"),
+            new("gifts_of_dwarven_lords_protective_belt_artifact_alt",             "Dwarven Gifts: Protective Belt (Alt)",             "Set"),
+            new("gifts_of_dwarven_lords_crimson_resonance_controller_artifact",    "Dwarven Gifts: Crimson Resonance Controller",      "Set"),
+            new("gifts_of_dwarven_lords_crimson_resonance_controller_artifact_alt","Dwarven Gifts: Crimson Resonance Controller (Alt)","Set"),
+            new("gifts_of_dwarven_lords_emerald_resonance_controller_artifact",    "Dwarven Gifts: Emerald Resonance Controller",      "Set"),
+            new("gifts_of_dwarven_lords_emerald_resonance_controller_artifact_alt","Dwarven Gifts: Emerald Resonance Controller (Alt)","Set"),
+
+            // ── Set: Elixir of Life ───────────────────────────────────────────────
+            new("elixir_of_life_flask_of_oblivion_artifact",                       "Elixir of Life: Flask of Oblivion",                "Set"),
+            new("elixir_of_life_lifeblood_fairy_artifact",                         "Elixir of Life: Lifeblood Fairy",                  "Set"),
+            new("elixir_of_life_ring_of_life_artifact",                            "Elixir of Life: Ring of Life",                     "Set"),
+
+            // ── Set: Shadow of Death ──────────────────────────────────────────────
+            new("shadow_of_death_cursed_armor_artifact",                           "Shadow of Death: Cursed Armor",                    "Set"),
+            new("shadow_of_death_bone_boots_artifact",                             "Shadow of Death: Bone Boots",                      "Set"),
+            new("shadow_of_death_second_shade_artifact",                           "Shadow of Death: Second Shade",                    "Set"),
+            new("shadow_of_death_dark_hatchet_artifact",                           "Shadow of Death: Dark Hatchet",                    "Set"),
+
+            // ── Set: Wanderer's Way ───────────────────────────────────────────────
+            new("wanderers_way_boots_of_travel_artifact",                          "Wanderer's Way: Boots of Travel",                  "Set"),
+            new("wanderers_way_backpack_artifact",                                 "Wanderer's Way: Backpack",                         "Set"),
+
+            // ── Set: Living Arrows ────────────────────────────────────────────────
+            new("living_arrows_shroomwood_bow_artifact",                           "Living Arrows: Shroomwood Bow",                    "Set"),
+            new("living_arrows_light_and_shade_cloak_artifact",                    "Living Arrows: Light and Shade Cloak",             "Set"),
+            new("living_arrows_quivering_quiver_artifact",                         "Living Arrows: Quivering Quiver",                  "Set"),
+
+            // ── Set: Duelist's Pride ──────────────────────────────────────────────
+            new("duelists_pride_rapier_artifact",                                  "Duelist's Pride: Rapier",                          "Set"),
+            new("duelists_pride_buckler_artifact",                                 "Duelist's Pride: Buckler",                         "Set"),
+            new("duelists_pride_brass_knuckles_artifact",                          "Duelist's Pride: Brass Knuckles",                  "Set"),
+
+            // ── Set: Ethereal Knowledge ───────────────────────────────────────────
+            new("ethereal_knowledge_glass_dagger_artifact",                        "Ethereal Knowledge: Glass Dagger",                 "Set"),
+            new("ethereal_knowledge_mirror_shoes_artifact",                        "Ethereal Knowledge: Mirror Shoes",                 "Set"),
+            new("ethereal_knowledge_vortex_dress_artifact",                        "Ethereal Knowledge: Vortex Dress",                 "Set"),
+            new("ethereal_knowledge_third_eye_artifact",                           "Ethereal Knowledge: Third Eye",                    "Set"),
+
+            // ── Set: Inner Song ───────────────────────────────────────────────────
+            new("inner_song_music_sheet_artifact",                                 "Inner Song: Music Sheet",                          "Set"),
+            new("inner_song_singing_pan_pipe_artifact",                            "Inner Song: Singing Pan Pipe",                     "Set"),
+            new("inner_song_fancy_mask_artifact",                                  "Inner Song: Fancy Mask",                           "Set"),
+
+            // ── Set: Power of the Dragon Father ──────────────────────────────────
+            new("power_of_the_dragon_father_red_dragon_flame_tongue_artifact",     "Dragon Father: Red Dragon Flame Tongue",           "Set"),
+            new("power_of_the_dragon_father_dragon_scale_shield_artifact",         "Dragon Father: Dragon Scale Shield",               "Set"),
+            new("power_of_the_dragon_father_dragon_scale_armor_artifact",          "Dragon Father: Dragon Scale Armor",                "Set"),
+            new("power_of_the_dragon_father_dragon_crest_artifact",                "Dragon Father: Dragon Crest",                      "Set"),
+            new("power_of_the_dragon_father_dragonbone_greaves_artifact",          "Dragon Father: Dragonbone Greaves",                "Set"),
+            new("power_of_the_dragon_father_slithering_sash_artifact",             "Dragon Father: Slithering Sash",                   "Set"),
+            new("power_of_the_dragon_father_dragon_wing_artifact",                 "Dragon Father: Dragon Wing",                       "Set"),
+            new("power_of_the_dragon_father_piercing_eye_of_a_dragon_artifact",    "Dragon Father: Piercing Eye of a Dragon",          "Set"),
+
+            // ── Set: Beelzebub's Blessing ─────────────────────────────────────────
+            new("beelzebubs_blessing_demon_claw_artifact",                         "Beelzebub's Blessing: Demon Claw",                 "Set"),
+            new("beelzebubs_blessing_chitinous_shield_artifact",                   "Beelzebub's Blessing: Chitinous Shield",           "Set"),
+            new("beelzebubs_blessing_heartbeat_artifact",                          "Beelzebub's Blessing: Heartbeat",                  "Set"),
+            new("beelzebubs_blessing_demon_crest_artifact",                        "Beelzebub's Blessing: Demon Crest",                "Set"),
+
+            // ── Set: Boreolos ─────────────────────────────────────────────────────
+            new("boreolos_hand_artifact",                                          "Boreolos: Hand",                                   "Set"),
+            new("boreolos_foot_artifact",                                          "Boreolos: Foot",                                   "Set"),
+            new("boreolos_heart_artifact",                                         "Boreolos: Heart",                                  "Set"),
+            new("boreolos_head_artifact",                                          "Boreolos: Head",                                   "Set"),
+
+            // ── Set: Holy Sigils ──────────────────────────────────────────────────
+            new("holy_sigil_of_roph_artifact",                                     "Holy Sigil of Roph",                               "Set"),
+            new("holy_sigil_of_eridore_artifact",                                  "Holy Sigil of Eridore",                            "Set"),
+            new("holy_sigil_of_mearea_artifact",                                   "Holy Sigil of Mearea",                             "Set"),
+            new("holy_sigil_of_insara_artifact",                                   "Holy Sigil of Insara",                             "Set"),
+            new("holy_sigil_of_quix_artifact",                                     "Holy Sigil of Quix",                               "Set"),
+            new("holy_sigil_of_the_seven_magi_artifact",                           "Holy Sigil of the Seven Magi",                     "Set"),
+            new("holy_sigil_of_the_second_man_artifact",                           "Holy Sigil of the Second Man",                     "Set"),
+            new("holy_sigil_of_uurdt_artifact",                                    "Holy Sigil of Uurdt",                              "Set"),
+
+            // ── Set: Rule of Shadow ───────────────────────────────────────────────
+            new("rule_of_shadow_liquid_silence_artifact",                          "Rule of Shadow: Liquid Silence",                   "Set"),
+            new("rule_of_shadow_the_truthmaker_artifact",                          "Rule of Shadow: The Truthmaker",                   "Set"),
+            new("rule_of_shadow_the_truthseeker_artifact",                         "Rule of Shadow: The Truthseeker",                  "Set"),
+            new("rule_of_shadow_nostrias_gaze_artifact",                           "Rule of Shadow: Nostria's Gaze",                   "Set"),
+
+            // ── Set: Ambassador's Word ────────────────────────────────────────────
+            new("ambassadors_word_diplomatic_gifts_artifact",                      "Ambassador's Word: Diplomatic Gifts",              "Set"),
+            new("ambassadors_word_ambassadors_sash_artifact",                      "Ambassador's Word: Ambassador's Sash",             "Set"),
+
+            // ── Set: Warrior's Strength ───────────────────────────────────────────
+            new("warriors_strength_warriors_belt_artifact",                        "Warrior's Strength: Warrior's Belt",               "Set"),
+            new("warriors_strength_warriors_oberegus_artifact",                    "Warrior's Strength: Warrior's Oberegus",           "Set"),
+
+            // ── Set: Keeper's Fortitude ───────────────────────────────────────────
+            new("keepers_fortitude_keepers_ring_artifact",                         "Keeper's Fortitude: Keeper's Ring",                "Set"),
+            new("keepers_fortitude_keepers_oberegus_artifact",                     "Keeper's Fortitude: Keeper's Oberegus",            "Set"),
+
+            // ── Set: Wizard's Might ───────────────────────────────────────────────
+            new("wizards_might_wizards_cloak_artifact",                            "Wizard's Might: Wizard's Cloak",                   "Set"),
+            new("wizards_might_wizards_oberegus_artifact",                         "Wizard's Might: Wizard's Oberegus",                "Set"),
+
+            // ── Set: Scholar's Wisdom ─────────────────────────────────────────────
+            new("scholars_wisdom_scholars_tiara_artifact",                         "Scholar's Wisdom: Scholar's Tiara",                "Set"),
+            new("scholars_wisdom_scholars_oberegus_artifact",                      "Scholar's Wisdom: Scholar's Oberegus",             "Set"),
+        ];
+
+        /// <summary>Known bannable spell IDs sourced from official game templates.</summary>
+        public static readonly BannableMagic[] BannableMagics =
+        [
+            new("neutral_magic_pocket_dimension", "Pocket Dimension"),
+            new("neutral_magic_light_gate",       "Light Gate"),
+            new("neutral_magic_town_portal",      "Town Portal"),
+            new("neutral_magic_dimension_door",   "Dimension Door"),
+            new("neutral_magic_shadow_form",      "Shadow Form"),
+        ];
+
+        /// <summary>
+        /// Converts a snake_case SID (with optional _artifact suffix) to a Title Case display name.
+        /// Used as fallback for IDs not in the catalog.
+        /// </summary>
+        public static string SidToDisplayName(string sid)
+        {
+            var s = sid.Replace("_artifact", "").Replace('_', ' ');
+            if (s.Length == 0) return sid;
+            return char.ToUpper(s[0]) + s[1..];
+        }
     }
 }

--- a/Olden Era - Template Editor/Models/Unfrozen/KnownValues.cs
+++ b/Olden Era - Template Editor/Models/Unfrozen/KnownValues.cs
@@ -567,6 +567,101 @@ namespace OldenEraTemplateEditor.Models
             new("neutral_magic_shadow_form",      "Shadow Form"),
         ];
 
+        /// <summary>A single learnable spell from the game's spell library.</summary>
+        public record SpellEntry(string Id, string Name, string School, int Tier);
+
+        /// <summary>All learnable spells grouped by school, sorted by tier within each school.</summary>
+        public static readonly SpellEntry[] KnownSpells =
+        [
+            // ── Neutral ─────────────────────────────────────────────────────────
+            new("neutral_magic_pocket_dimension", "Pocket Dimension", "neutral", 2),
+            new("neutral_magic_second_sight",     "Second Sight",     "neutral", 2),
+            new("neutral_magic_shadow_form",      "Shadowflight",     "neutral", 3),
+            new("neutral_magic_town_portal",      "Town Portal",      "neutral", 3),
+            new("neutral_magic_dimension_door",   "Dimension Door",   "neutral", 4),
+            new("neutral_magic_light_gate",       "Gate of Light",    "neutral", 4),
+
+            // ── Day ─────────────────────────────────────────────────────────────
+            new("day_2_magic_sharp_edge",       "Blessing",          "day", 1),
+            new("day_3_magic_haste",            "Haste",             "day", 1),
+            new("day_1_magic_healing_water",    "Healing Water",     "day", 1),
+            new("day_5_magic_shorten_shadow",   "Shorten Shadow",    "day", 1),
+            new("day_4_magic_favorable_wind",   "Favorable Wind",    "day", 2),
+            new("day_17_magic_clear_view",      "From a Bird's Eye", "day", 2),
+            new("day_7_magic_inner_light",      "Inner Light",       "day", 2),
+            new("day_6_magic_cleansing_ray",    "Weakening Ray",     "day", 2),
+            new("day_9_magic_arinas_hymn",      "Arina's Touch",     "day", 3),
+            new("day_11_magic_masterful_parry", "Riposte",           "day", 3),
+            new("day_10_magic_second_song",     "Song of Power",     "day", 3),
+            new("day_8_magic_taunt",            "Taunt",             "day", 3),
+            new("day_18_magic_farsight",        "Clear Fog",         "day", 4),
+            new("day_13_magic_holy_arms",       "Heavenly Blades",   "day", 4),
+            new("day_12_magic_radiant_armor",   "Radiant Armor",     "day", 4),
+            new("day_14_magic_vengeance",       "Vengeance",         "day", 4),
+            new("day_16_magic_arinas_chosen",   "Arina's Chosen",    "day", 5),
+            new("day_15_magic_judgement",       "Judgement",         "day", 5),
+
+            // ── Night ───────────────────────────────────────────────────────────
+            new("night_4_magic_despair",           "Despair",           "night", 1),
+            new("night_3_magic_enlarge_shadow",    "Enlarge Shadow",    "night", 1),
+            new("night_7_magic_fatal_decay",       "Fatal Decay",       "night", 1),
+            new("night_1_magic_unnatural_calm",    "Unnatural Calm",    "night", 1),
+            new("night_17_magic_read_minds",       "Read Minds",        "night", 2),
+            new("night_5_magic_shade_cloak",       "Shade Cloak",       "night", 2),
+            new("night_6_magic_deaths_grip",       "Umbral Grip",       "night", 2),
+            new("night_2_magic_web",               "Web",               "night", 2),
+            new("night_18_magic_nairas_veil",      "Naira's Veil",      "night", 3),
+            new("night_10_magic_silence",          "Silence",           "night", 3),
+            new("night_8_magic_sleep",             "Sleep",             "night", 3),
+            new("night_9_magic_twilight",          "Twilight",          "night", 3),
+            new("night_13_magic_berserker",        "Berserk",           "night", 4),
+            new("night_12_magic_summon_starchild", "Summon Starchild",  "night", 4),
+            new("night_11_magic_vulnerability",    "Vulnerability",     "night", 4),
+            new("night_15_magic_deaths_call",      "Coup de Grace",     "night", 5),
+            new("night_14_magic_nairas_kiss",      "Naira's Kiss",      "night", 5),
+            new("night_16_magic_shadow_army",      "Shadow Army",       "night", 5),
+
+            // ── Primal ──────────────────────────────────────────────────────────
+            new("primal_17_magic_groundsight",              "Groundsight",           "primal", 1),
+            new("primal_1_magic_thunderbolt",               "Lightning Bolt",        "primal", 1),
+            new("primal_2_magic_thick_hide",                "Thick Hide",            "primal", 1),
+            new("primal_5_magic_crystal_crown",             "Crystal Crown",         "primal", 2),
+            new("primal_4_magic_fire_globe",                "Fireball",              "primal", 2),
+            new("primal_6_magic_ice_bolt",                  "Ice Bolt",              "primal", 2),
+            new("primal_3_magic_wean",                      "Wean",                  "primal", 2),
+            new("primal_8_magic_cave_in",                   "Cave In",               "primal", 3),
+            new("primal_9_magic_earths_rage",               "Earth's Rage",          "primal", 3),
+            new("primal_7_magic_wall_of_flame",             "Firewall",              "primal", 3),
+            new("primal_16_magic_stone_fangs",              "Stone Fangs",           "primal", 3),
+            new("primal_10_magic_primordial_purity",        "Anti-Magic",            "primal", 4),
+            new("primal_12_magic_chain_lightning",          "Chain Lightning",       "primal", 4),
+            new("primal_13_magic_avalanche",                "Circle of Winter",      "primal", 4),
+            new("primal_18_magic_primordial_chaos",         "Primordial Chaos",      "primal", 4),
+            new("primal_11_magic_armageddon",               "Armageddon",            "primal", 5),
+            new("primal_14_magic_hksmillas_rampage",        "Hksmilla's Rampage",    "primal", 5),
+            new("primal_15_magic_summon_primal_remnant",    "Summon Primal Remnant", "primal", 5),
+
+            // ── Space ───────────────────────────────────────────────────────────
+            new("space_1_magic_early_start",          "Early Start",         "space", 1),
+            new("space_3_magic_energyze",             "Energize",            "space", 1),
+            new("space_11_magic_decimate",            "Guillotine",          "space", 1),
+            new("space_4_magic_optical_illusion",     "Optical Illusion",    "space", 1),
+            new("space_6_magic_blink",                "Blink",               "space", 2),
+            new("space_8_magic_carapace",             "Carapace",            "space", 2),
+            new("space_2_magic_energy_explosion",     "Energy Explosion",    "space", 2),
+            new("space_17_magic_reinforcements",      "Reinforcements",      "space", 2),
+            new("space_18_magic_assemble",            "Assemble!",           "space", 3),
+            new("space_9_magic_impending_fate",       "Impending Fate",      "space", 3),
+            new("space_7_magic_shackles",             "Shackles",            "space", 3),
+            new("space_5_magic_trap_jaws",            "Temporal Spheres",    "space", 3),
+            new("space_10_magic_mirror_copy",         "Mirror Copy",         "space", 4),
+            new("space_12_magic_rewind",              "Rewind Life",         "space", 4),
+            new("space_15_magic_trap_snare",          "Spatial Snare",       "space", 4),
+            new("space_13_magic_black_hole",          "Black Hole",          "space", 5),
+            new("space_14_magic_doreaths_tide",       "Doreath's Tide",      "space", 5),
+            new("space_16_magic_reality_distortion",  "Reality Distortion",  "space", 5),
+        ];
+
         /// <summary>
         /// Converts a snake_case SID (with optional _artifact suffix) to a Title Case display name.
         /// Used as fallback for IDs not in the catalog.

--- a/Olden Era - Template Editor/Models/Unfrozen/Miscellaneous.cs
+++ b/Olden Era - Template Editor/Models/Unfrozen/Miscellaneous.cs
@@ -19,5 +19,8 @@ namespace OldenEraTemplateEditor.Models
     {
         [JsonPropertyName("items")]
         public List<string>? Items { get; set; }
+
+        [JsonPropertyName("magics")]
+        public List<string>? Magics { get; set; }
     }
 }

--- a/Olden Era - Template Editor/Services/TemplateGenerator.cs
+++ b/Olden Era - Template Editor/Services/TemplateGenerator.cs
@@ -357,21 +357,21 @@ namespace Olden_Era___Template_Editor.Services
             EncounterHoles = false,
             FactionLawsExpModifier = PercentToModifier(settings.FactionLawsExpPercent),
             AstrologyExpModifier = PercentToModifier(settings.AstrologyExpPercent),
-            Bonuses =
-            [
-                new Bonus
-                {
-                    Sid = "add_bonus_hero_stat",
-                    ReceiverSide = -1,
-                    ReceiverFilter = "all_heroes",
-                    Parameters = ["movementBonus", "0"]
-                }
-            ],
+            Bonuses = BuildBonuses(settings.Bonuses),
             WinConditions = BuildAdvancedWinConditions(settings, effectiveVictoryCondition)
         };
 
         private static double PercentToModifier(int percent) =>
             Math.Round(Math.Clamp(percent, 25, 200) / 100.0, 2, MidpointRounding.AwayFromZero);
+
+        private static List<Bonus>? BuildBonuses(List<OldenEraTemplateEditor.Models.BonusEntry> entries)
+        {
+            if (entries.Count == 0) return null;
+            var result = new List<Bonus>();
+            foreach (var entry in entries)
+                result.AddRange(entry.ToBonuses());
+            return result.Count > 0 ? result : null;
+        }
 
         /// <summary>
         /// Parses newline-separated "sid=guardValue" lines into a ValueOverride list.

--- a/Olden Era - Template Editor/Services/TemplateGenerator.cs
+++ b/Olden Era - Template Editor/Services/TemplateGenerator.cs
@@ -69,6 +69,8 @@ namespace Olden_Era___Template_Editor.Services
                 SizeX = settings.MapSize,
                 SizeZ = settings.MapSize,
                 GameRules = BuildGameRules(settings, effectiveVictoryCondition),
+                ValueOverrides = BuildValueOverrides(settings.ValueOverridesText),
+                GlobalBans = BuildGlobalBans(settings.BannedItems, settings.BannedMagics),
                 Variants = [BuildVariant(settings, playerLetters, neutralZones, tuning, holdCityNeutralLetter, useCityHold && settings.Topology == MapTopology.HubAndSpoke)],
                 ZoneLayouts = BuildZoneLayouts(),
                 MandatoryContent = BuildAllMandatoryContent(playerLetters, neutralZones, settings),
@@ -370,6 +372,50 @@ namespace Olden_Era___Template_Editor.Services
 
         private static double PercentToModifier(int percent) =>
             Math.Round(Math.Clamp(percent, 25, 200) / 100.0, 2, MidpointRounding.AwayFromZero);
+
+        /// <summary>
+        /// Parses newline-separated "sid=guardValue" lines into a ValueOverride list.
+        /// Lines that are blank or unparseable are silently skipped.
+        /// </summary>
+        private static List<ValueOverride>? BuildValueOverrides(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+            var list = new List<ValueOverride>();
+            foreach (var line in raw.Split('\n'))
+            {
+                var trimmed = line.Trim();
+                if (string.IsNullOrEmpty(trimmed)) continue;
+                var eq = trimmed.IndexOf('=');
+                if (eq <= 0) continue;
+                var sid = trimmed[..eq].Trim();
+                if (string.IsNullOrEmpty(sid)) continue;
+                if (!int.TryParse(trimmed[(eq + 1)..].Trim(), out int gv)) continue;
+                list.Add(new ValueOverride { Sid = sid, Variant = -1, GuardValue = gv });
+            }
+            return list.Count > 0 ? list : null;
+        }
+
+        /// <summary>
+        /// Builds a GlobalBans object from newline-separated item and magic ID strings.
+        /// Returns null when both are empty.
+        /// </summary>
+        private static GlobalBans? BuildGlobalBans(string rawItems, string rawMagics)
+        {
+            static List<string>? ParseLines(string raw)
+            {
+                if (string.IsNullOrWhiteSpace(raw)) return null;
+                var list = raw.Split('\n')
+                              .Select(l => l.Trim())
+                              .Where(l => l.Length > 0)
+                              .ToList();
+                return list.Count > 0 ? list : null;
+            }
+
+            var items  = ParseLines(rawItems);
+            var magics = ParseLines(rawMagics);
+            if (items == null && magics == null) return null;
+            return new GlobalBans { Items = items, Magics = magics };
+        }
 
 
 

--- a/Olden Era - Template Editor/SpellPickerWindow.xaml
+++ b/Olden Era - Template Editor/SpellPickerWindow.xaml
@@ -1,0 +1,72 @@
+<Window x:Class="Olden_Era___Template_Editor.SpellPickerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Add Spell Bonus" Width="480" Height="580"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize"
+        MinWidth="380" MinHeight="400"
+        Background="#221E15"
+        Foreground="#E8D5A3"
+        FontFamily="Segoe UI" FontSize="13">
+
+    <DockPanel Margin="12">
+
+        <!-- Search box -->
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+            <TextBox x:Name="TxtSearch"
+                     TextChanged="TxtSearch_TextChanged"
+                     Height="28"
+                     Background="#2C2619" Foreground="#E8D5A3"
+                     BorderBrush="#5A4A28" BorderThickness="1"
+                     CaretBrush="#C9A84C" SelectionBrush="#8A6E30"
+                     Padding="6,0"/>
+        </StackPanel>
+
+        <!-- Make free + Buttons (bottom) -->
+        <Grid DockPanel.Dock="Bottom" Margin="0,8,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <CheckBox Grid.Column="0" x:Name="ChkMakeFree"
+                      Content="Make free (zero cast cost)"
+                      Foreground="#E8D5A3" VerticalAlignment="Center"/>
+            <StackPanel Grid.Column="1" Orientation="Horizontal">
+                <Button x:Name="BtnAdd" Content="Add Selected"
+                        Width="120" Height="28" Margin="0,0,8,0"
+                        IsDefault="True" IsEnabled="False"
+                        Click="BtnAdd_Click"/>
+                <Button Content="Cancel"
+                        Width="80" Height="28"
+                        IsCancel="True"
+                        Click="BtnCancel_Click"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Spell tree -->
+        <TreeView x:Name="TvSpells"
+                  PreviewMouseLeftButtonDown="TvSpells_PreviewMouseLeftButtonDown"
+                  MouseDoubleClick="TvSpells_MouseDoubleClick"
+                  Background="#2C2619"
+                  Foreground="#E8D5A3"
+                  BorderBrush="#5A4A28" BorderThickness="1">
+            <TreeView.Resources>
+                <Style TargetType="TreeViewItem">
+                    <Setter Property="Background"  Value="Transparent"/>
+                    <Setter Property="Foreground"  Value="#E8D5A3"/>
+                    <Setter Property="Padding"     Value="3,2"/>
+                    <Setter Property="IsExpanded"  Value="True"/>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#3A3020"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter Property="Background" Value="Transparent"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TreeView.Resources>
+        </TreeView>
+
+    </DockPanel>
+</Window>

--- a/Olden Era - Template Editor/SpellPickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/SpellPickerWindow.xaml.cs
@@ -1,0 +1,239 @@
+using OldenEraTemplateEditor.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Olden_Era___Template_Editor
+{
+    public partial class SpellPickerWindow : Window
+    {
+        public string?      SelectedId  => SelectedIds.Count > 0 ? SelectedIds[0] : null;
+        public List<string> SelectedIds { get; private set; } = [];
+        public bool         MakeFree    { get; private set; }
+
+        private readonly HashSet<string>       _alreadyPicked;
+        private readonly HashSet<string>       _collapsedSchools = [];
+        private readonly HashSet<TreeViewItem> _checkedLeaves    = [];
+
+        private static readonly SolidColorBrush CheckedBrush   = new(Color.FromRgb(0x5A, 0x4A, 0x28));
+        private static readonly SolidColorBrush CheckMarkBrush = new(Color.FromRgb(0xC9, 0xA8, 0x4C));
+
+        private static readonly Dictionary<string, Color> SchoolColors = new()
+        {
+            ["neutral"] = Color.FromRgb(0xA0, 0xA0, 0xA0),
+            ["day"]     = Color.FromRgb(0xC8, 0xB8, 0x7A),
+            ["night"]   = Color.FromRgb(0x9B, 0x7E, 0xD4),
+            ["space"]   = Color.FromRgb(0x7E, 0xC9, 0xD0),
+            ["primal"]  = Color.FromRgb(0xD4, 0x7A, 0x48),
+        };
+
+        private static readonly Dictionary<string, string> SchoolDisplayNames = new()
+        {
+            ["neutral"] = "Neutral",
+            ["day"]     = "Day",
+            ["night"]   = "Night",
+            ["space"]   = "Space",
+            ["primal"]  = "Primal",
+        };
+
+        private static readonly Dictionary<string, int> SchoolOrder = new()
+        {
+            ["neutral"] = 0, ["day"] = 1, ["night"] = 2, ["space"] = 3, ["primal"] = 4,
+        };
+
+        public SpellPickerWindow(IEnumerable<string>? alreadyPicked = null)
+        {
+            InitializeComponent();
+            _alreadyPicked = alreadyPicked?.ToHashSet() ?? [];
+            RefreshTree(string.Empty);
+            TxtSearch.Focus();
+        }
+
+        // ── Tree building ─────────────────────────────────────────────────────────
+
+        private void RefreshTree(string filter)
+        {
+            foreach (TreeViewItem si in TvSpells.Items)
+                if (si.Tag is string school)
+                {
+                    if (si.IsExpanded) _collapsedSchools.Remove(school);
+                    else               _collapsedSchools.Add(school);
+                }
+
+            _checkedLeaves.Clear();
+            TvSpells.Items.Clear();
+
+            var groups = KnownValues.KnownSpells
+                .Where(s => !_alreadyPicked.Contains(s.Id))
+                .Where(s => string.IsNullOrEmpty(filter)
+                         || s.Name.Contains(filter, System.StringComparison.OrdinalIgnoreCase)
+                         || s.Id.Contains(filter, System.StringComparison.OrdinalIgnoreCase)
+                         || s.School.Contains(filter, System.StringComparison.OrdinalIgnoreCase))
+                .GroupBy(s => s.School)
+                .OrderBy(g => SchoolOrder.GetValueOrDefault(g.Key, 99));
+
+            foreach (var group in groups)
+            {
+                var schoolKey = group.Key;
+                var displayName = SchoolDisplayNames.GetValueOrDefault(schoolKey, schoolKey);
+                var schoolNode = new TreeViewItem
+                {
+                    Tag        = schoolKey,
+                    IsExpanded = !_collapsedSchools.Contains(schoolKey),
+                    Header     = BuildSchoolHeader(schoolKey, displayName, group.Count()),
+                };
+
+                foreach (var spell in group.OrderBy(s => s.Tier).ThenBy(s => s.Name))
+                    schoolNode.Items.Add(BuildLeafItem(spell));
+
+                TvSpells.Items.Add(schoolNode);
+            }
+
+            UpdateAddButton();
+        }
+
+        private static FrameworkElement BuildSchoolHeader(string schoolKey, string displayName, int count)
+        {
+            var color = SchoolColors.GetValueOrDefault(schoolKey, Color.FromRgb(0xC9, 0xA8, 0x4C));
+            var sp = new StackPanel { Orientation = System.Windows.Controls.Orientation.Horizontal };
+            sp.Children.Add(new TextBlock
+            {
+                Text              = displayName,
+                FontWeight        = FontWeights.SemiBold,
+                Foreground        = new SolidColorBrush(color),
+                Margin            = new Thickness(0, 0, 6, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            sp.Children.Add(new TextBlock
+            {
+                Text              = $"({count})",
+                Foreground        = new SolidColorBrush(Color.FromRgb(0x9A, 0x8A, 0x6A)),
+                FontSize          = 11,
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            return sp;
+        }
+
+        private static TreeViewItem BuildLeafItem(KnownValues.SpellEntry spell)
+        {
+            var chk = new TextBlock
+            {
+                Name              = "ChkMark",
+                Text              = "",
+                Width             = 16,
+                Foreground        = CheckMarkBrush,
+                FontWeight        = FontWeights.Bold,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin            = new Thickness(0, 0, 4, 0),
+            };
+
+            var tier = new TextBlock
+            {
+                Text              = $"[T{spell.Tier}]",
+                Width             = 32,
+                Foreground        = new SolidColorBrush(Color.FromRgb(0x9A, 0x8A, 0x6A)),
+                FontFamily        = new FontFamily("Consolas"),
+                FontSize          = 11,
+                Margin            = new Thickness(0, 0, 8, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+
+            var name = new TextBlock
+            {
+                Text              = spell.Name,
+                Foreground        = new SolidColorBrush(Color.FromRgb(0xE8, 0xD5, 0xA3)),
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+
+            var sp = new StackPanel { Orientation = System.Windows.Controls.Orientation.Horizontal };
+            sp.Children.Add(chk);
+            sp.Children.Add(tier);
+            sp.Children.Add(name);
+
+            return new TreeViewItem { Header = sp, Tag = spell };
+        }
+
+        // ── Check-toggle helpers ──────────────────────────────────────────────────
+
+        private static TextBlock? GetCheckMark(TreeViewItem item)
+            => item.Header is StackPanel sp && sp.Children.Count > 0
+                ? sp.Children[0] as TextBlock
+                : null;
+
+        private void ToggleLeaf(TreeViewItem item)
+        {
+            if (_checkedLeaves.Contains(item))
+            {
+                _checkedLeaves.Remove(item);
+                item.ClearValue(TreeViewItem.BackgroundProperty);
+                if (GetCheckMark(item) is { } chk) chk.Text = "";
+            }
+            else
+            {
+                _checkedLeaves.Add(item);
+                item.Background = CheckedBrush;
+                if (GetCheckMark(item) is { } chk) chk.Text = "✓";
+            }
+            UpdateAddButton();
+        }
+
+        private void UpdateAddButton()
+        {
+            int n = _checkedLeaves.Count;
+            BtnAdd.Content   = n > 1 ? $"Add Selected ({n})" : "Add Selected";
+            BtnAdd.IsEnabled = n > 0;
+        }
+
+        private static TreeViewItem? FindLeafFromSource(object originalSource)
+        {
+            var dep = originalSource as DependencyObject;
+            while (dep != null)
+            {
+                if (dep is TreeViewItem tvi && tvi.Tag is KnownValues.SpellEntry)
+                    return tvi;
+                dep = VisualTreeHelper.GetParent(dep);
+            }
+            return null;
+        }
+
+        // ── Event handlers ────────────────────────────────────────────────────────
+
+        private void TxtSearch_TextChanged(object sender, TextChangedEventArgs e)
+            => RefreshTree(TxtSearch.Text);
+
+        private void TvSpells_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var leaf = FindLeafFromSource(e.OriginalSource);
+            if (leaf == null) return;
+            ToggleLeaf(leaf);
+            e.Handled = true;
+        }
+
+        private void TvSpells_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            var leaf = FindLeafFromSource(e.OriginalSource);
+            if (leaf == null) return;
+            if (!_checkedLeaves.Contains(leaf)) ToggleLeaf(leaf);
+            CommitAll();
+        }
+
+        private void CommitAll()
+        {
+            SelectedIds = _checkedLeaves
+                .Select(tvi => ((KnownValues.SpellEntry)tvi.Tag!).Id)
+                .ToList();
+            MakeFree = ChkMakeFree.IsChecked == true;
+            if (SelectedIds.Count > 0)
+                DialogResult = true;
+        }
+
+        private void BtnAdd_Click(object sender, RoutedEventArgs e)
+            => CommitAll();
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e)
+            => DialogResult = false;
+    }
+}

--- a/Olden Era - Template Editor/SpellPickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/SpellPickerWindow.xaml.cs
@@ -44,10 +44,12 @@ namespace Olden_Era___Template_Editor
             ["neutral"] = 0, ["day"] = 1, ["night"] = 2, ["space"] = 3, ["primal"] = 4,
         };
 
-        public SpellPickerWindow(IEnumerable<string>? alreadyPicked = null)
+        public SpellPickerWindow(IEnumerable<string>? alreadyPicked = null, bool showMakeFree = true)
         {
             InitializeComponent();
             _alreadyPicked = alreadyPicked?.ToHashSet() ?? [];
+            if (!showMakeFree)
+                ChkMakeFree.Visibility = Visibility.Collapsed;
             RefreshTree(string.Empty);
             TxtSearch.Focus();
         }

--- a/Olden Era - Template Editor/ValueOverridePickerWindow.xaml
+++ b/Olden Era - Template Editor/ValueOverridePickerWindow.xaml
@@ -1,0 +1,94 @@
+<Window x:Class="Olden_Era___Template_Editor.ValueOverridePickerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Add Value Overrides" Width="560" Height="620"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize"
+        MinWidth="400" MinHeight="350"
+        Background="#221E15"
+        Foreground="#E8D5A3"
+        FontFamily="Segoe UI" FontSize="13">
+
+    <DockPanel Margin="12">
+
+        <!-- Search box -->
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+            <TextBox x:Name="TxtSearch"
+                     TextChanged="TxtSearch_TextChanged"
+                     Height="28"
+                     Background="#2C2619" Foreground="#E8D5A3"
+                     BorderBrush="#5A4A28" BorderThickness="1"
+                     CaretBrush="#C9A84C" SelectionBrush="#8A6E30"
+                     Padding="6,0"/>
+        </StackPanel>
+
+        <!-- Guard value row -->
+        <Grid DockPanel.Dock="Top" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="120"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="Guard value for selected:"
+                       VerticalAlignment="Center" Margin="0,0,8,0"
+                       Foreground="#9A8A6A" FontSize="12"/>
+            <TextBox Grid.Column="1" x:Name="TxtGuardValue"
+                     Height="26" Text="5000"
+                     Background="#2C2619" Foreground="#E8D5A3"
+                     BorderBrush="#5A4A28" BorderThickness="1"
+                     CaretBrush="#C9A84C" Padding="6,0"
+                     FontFamily="Consolas" FontSize="12"
+                     ToolTip="Guard value applied to all checked items"/>
+        </Grid>
+
+        <!-- Buttons (bottom) -->
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
+                    HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button x:Name="BtnAdd" Content="Add Selected"
+                    Width="120" Height="28" Margin="0,0,8,0"
+                    IsDefault="True"
+                    Click="BtnAdd_Click"/>
+            <Button Content="Cancel"
+                    Width="80" Height="28"
+                    IsCancel="True"
+                    Click="BtnCancel_Click"/>
+        </StackPanel>
+
+        <!-- Object SID list -->
+        <ListBox x:Name="LbSids"
+                 PreviewMouseLeftButtonDown="LbSids_PreviewMouseLeftButtonDown"
+                 Background="#2C2619"
+                 Foreground="#E8D5A3"
+                 BorderBrush="#5A4A28" BorderThickness="1">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="Padding"    Value="4,3"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="ListBoxItem">
+                                <Border Background="{TemplateBinding Background}"
+                                        Padding="{TemplateBinding Padding}">
+                                    <ContentPresenter/>
+                                </Border>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ListBox.ItemContainerStyle>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="ChkMark" Text="" Width="16"
+                                   Foreground="#C9A84C" FontWeight="Bold"
+                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <TextBlock Text="{Binding}"
+                                   FontFamily="Consolas" FontSize="12"
+                                   Foreground="#E8D5A3"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+    </DockPanel>
+</Window>

--- a/Olden Era - Template Editor/ValueOverridePickerWindow.xaml.cs
+++ b/Olden Era - Template Editor/ValueOverridePickerWindow.xaml.cs
@@ -1,0 +1,132 @@
+using OldenEraTemplateEditor.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Olden_Era___Template_Editor
+{
+    public partial class ValueOverridePickerWindow : Window
+    {
+        /// <summary>Lines in "sid=guardValue" format to append to the overrides text box.</summary>
+        public List<string> ResultLines { get; private set; } = [];
+
+        private readonly HashSet<ListBoxItem> _checkedItems = [];
+        private List<string> _filtered = [];
+
+        private static readonly SolidColorBrush CheckedBrush = new(Color.FromRgb(0x5A, 0x4A, 0x28));
+
+        public ValueOverridePickerWindow(IEnumerable<string> alreadyOverridden)
+        {
+            InitializeComponent();
+            var existing = new HashSet<string>(alreadyOverridden);
+            _filtered = KnownValues.ObjectSids
+                .Where(s => !existing.Contains(s))
+                .OrderBy(s => s)
+                .ToList();
+            LbSids.ItemsSource = _filtered;
+            UpdateAddButton();
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────────────
+
+        private static TextBlock? GetCheckMark(ListBoxItem lbi)
+        {
+            if (lbi.ContentTemplate?.LoadContent() is not null) { }
+            // Walk visual tree to find the ChkMark TextBlock
+            if (VisualTreeHelper.GetChildrenCount(lbi) == 0) return null;
+            return FindCheckMark(lbi);
+        }
+
+        private static TextBlock? FindCheckMark(DependencyObject parent)
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is TextBlock tb && tb.Name == "ChkMark") return tb;
+                var found = FindCheckMark(child);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        private void ToggleItem(ListBoxItem lbi)
+        {
+            if (_checkedItems.Contains(lbi))
+            {
+                _checkedItems.Remove(lbi);
+                lbi.ClearValue(ListBoxItem.BackgroundProperty);
+                if (FindCheckMark(lbi) is { } chk) chk.Text = "";
+            }
+            else
+            {
+                _checkedItems.Add(lbi);
+                lbi.Background = CheckedBrush;
+                if (FindCheckMark(lbi) is { } chk) chk.Text = "✓";
+            }
+            UpdateAddButton();
+        }
+
+        private static ListBoxItem? FindListBoxItem(object originalSource)
+        {
+            var dep = originalSource as DependencyObject;
+            while (dep != null)
+            {
+                if (dep is ListBoxItem lbi) return lbi;
+                dep = VisualTreeHelper.GetParent(dep);
+            }
+            return null;
+        }
+
+        private void UpdateAddButton()
+        {
+            int n = _checkedItems.Count;
+            BtnAdd.Content   = n > 1 ? $"Add Selected ({n})" : "Add Selected";
+            BtnAdd.IsEnabled = n > 0;
+        }
+
+        private void RefreshList(string filter)
+        {
+            _checkedItems.Clear();
+            _filtered = KnownValues.ObjectSids
+                .Where(s => string.IsNullOrEmpty(filter)
+                         || s.Contains(filter, System.StringComparison.OrdinalIgnoreCase))
+                .OrderBy(s => s)
+                .ToList();
+            LbSids.ItemsSource = null;
+            LbSids.ItemsSource = _filtered;
+            UpdateAddButton();
+        }
+
+        // ── Event handlers ────────────────────────────────────────────────────────
+
+        private void TxtSearch_TextChanged(object sender, TextChangedEventArgs e)
+            => RefreshList(TxtSearch.Text);
+
+        private void LbSids_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var lbi = FindListBoxItem(e.OriginalSource);
+            if (lbi == null) return;
+            lbi.ApplyTemplate(); // ensure visual tree is materialised
+            ToggleItem(lbi);
+            e.Handled = true;
+        }
+
+        private void BtnAdd_Click(object sender, RoutedEventArgs e)
+        {
+            if (!int.TryParse(TxtGuardValue.Text.Trim(), out int gv)) gv = 5000;
+            ResultLines = _checkedItems
+                .Select(lbi => lbi.Content is string sid ? $"{sid}={gv}" : null)
+                .Where(l => l != null)
+                .Select(l => l!)
+                .ToList();
+            if (ResultLines.Count > 0)
+                DialogResult = true;
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e)
+            => DialogResult = false;
+    }
+}


### PR DESCRIPTION
Adds a dedicated **Bonuses & Bans** tab to the template editor, replacing the previous plain text-box approach for bans and adding first-class support for game-start bonuses and value overrides.

## What's new

### Game-start bonuses
- New "Bonuses" section with a `+ Add` button that opens a `BonusPickerWindow`
- Supports all bonus types: Town Portal (free), Spell, Unit Multiplier, Movement Bonus, Starting Item, and starting resources (Gold/Gems/Crystals/Mercury)
- Bonus entries are displayed in a styled list and serialized to the `gameRules.bonuses` array in the generated `.rmg.json`

### Ban picker
- Replaces the free-text ban inputs with a searchable `ItemPickerWindow` grouped by artifact/spell category
- **Checkbox-style multi-select** — click any number of entries, all are added at once
- Works for both artifact bans (`bannedItems`) and magic bans (`bannedMagics`)
- Selecting multiple items when adding a bonus (Starting Item type) also adds one entry per item in a single operation

### Value overrides picker
- New `+` strip button next to the value overrides text box opens `ValueOverridePickerWindow`
- Same checkbox multi-select UX as the ban picker, filtered to known object SIDs
- A guard value field (default 5000) applies to all checked entries; results are appended as `sid=guardValue` lines

### UI polish
- All list `+ Add` buttons are styled as left-side border strips (themed dark gold), consistent across every list in the tab

## Examples

You can set up starting conditions as you want. Adding certain spells/resources/artifacts/starting units or simply movement points.

Same goes for bannable items and spells.

<img width="1096" height="913" alt="image" src="https://github.com/user-attachments/assets/d2ecb318-cd8f-4fef-bc40-e02fa0d7cc33" /><br/><br/>


Adding bonuses invokes a modal which lets you chose what type of bonus to add and whether it should effect starting hero or every hero that comes.

<img width="404" height="353" alt="image" src="https://github.com/user-attachments/assets/87588b19-bbd0-4afc-ac92-151e0e13594d" /><br/><br/>



Item picker is simple yet easy and convenient, works by clicking to select/unselect. Has prefiltered categories in collapsible list.

<img width="878" height="741" alt="image" src="https://github.com/user-attachments/assets/0814b586-39ef-48b0-af76-ef3ae65de028" />
<br/><br/>
The result of this configuration has been tested. Bans work by removing the spawning conditions of artifacts and spells.

<img width="1127" height="1188" alt="image" src="https://github.com/user-attachments/assets/3183635b-b401-425a-b7c4-e3109e2d9fc7" />
<img width="1633" height="1339" alt="image" src="https://github.com/user-attachments/assets/e644f708-cf06-4531-aa0c-87aa0ea26929" />

As instructed it gives way harder fights against ore mine
<img width="505" height="661" alt="image" src="https://github.com/user-attachments/assets/e8ddb0ca-c1aa-4f78-bcf7-0909eaf12f49" />

