### PR TITLE
Expand player zone customization options

### DIFF
--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -963,6 +963,23 @@
                                                     Style="{StaticResource ToolbarButton}"
                                                     Click="BtnAddResourceBankContent_Click"/>
                                         </DockPanel>
+                                        <!-- Storage Structures -->
+                                        <DockPanel x:Name="StickyStorageStructures" Visibility="Collapsed">
+                                            <TextBlock Text="◆  Storage Structures"
+                                                       Style="{StaticResource SectionHeader}"
+                                                       VerticalAlignment="Center"
+                                                       Margin="0,0,10,0"
+                                                       DockPanel.Dock="Left"/>
+                                            <ComboBox x:Name="CmbStorageStructureContentPresetSticky"
+                                                      Width="170"
+                                                      DockPanel.Dock="Left"/>
+                                            <Button Content="Add Content"
+                                                    Width="100"
+                                                    HorizontalAlignment="Left"
+                                                    Margin="8,0,0,0"
+                                                    Style="{StaticResource ToolbarButton}"
+                                                    Click="BtnAddStorageStructureContent_Click"/>
+                                        </DockPanel>
                                     </Grid>
                                     <ScrollViewer x:Name="PlayerZonesScrollViewer"
                                                   VerticalScrollBarVisibility="Auto"
@@ -1283,6 +1300,103 @@
                                                         Click="BtnAddResourceBankContent_Click"/>
                                             </DockPanel>
                                             <ItemsControl x:Name="ResourceBanksControl" ItemsSource="{Binding ResourceBankContentItems}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="{x:Type local:ZoneContentItemUI}">
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="150"/>
+                                                                <ColumnDefinition Width="8"/>
+                                                                <ColumnDefinition Width="200"/>
+                                                                <ColumnDefinition Width="8"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Grid.RowDefinitions>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="8"/>
+                                                            </Grid.RowDefinitions>
+                                                            <Grid Grid.Row="0" Grid.Column="0">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="30"/>
+                                                                    <ColumnDefinition Width="*"/>
+                                                                </Grid.ColumnDefinitions>
+                                                                <Button Grid.Column="0"
+                                                                        Content="x"
+                                                                        Width="20" Height="16"
+                                                                        Margin="4,0,0,0" Padding="0"
+                                                                        FontSize="10"
+                                                                        ToolTip="Remove content"
+                                                                        Style="{StaticResource ToolbarButton}"
+                                                                        Click="BtnRemoveZoneContent_Click"/>
+                                                                <TextBlock Grid.Column="1"
+                                                                           Text="{Binding SidMapping.Name}"
+                                                                           VerticalAlignment="Center"
+                                                                           TextTrimming="CharacterEllipsis"/>
+                                                            </Grid>
+                                                            <Grid Grid.Row="0" Grid.Column="2">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="Auto"/>
+                                                                    <ColumnDefinition Width="*"/>
+                                                                </Grid.ColumnDefinitions>
+                                                                <TextBlock Grid.Column="0"
+                                                                           Text="{Binding Count, StringFormat={}{0:0}}"
+                                                                           Style="{StaticResource ValueText}"
+                                                                           VerticalAlignment="Center"
+                                                                           Margin="0,0,6,0"/>
+                                                                <Slider Grid.Column="1"
+                                                                        Minimum="0" Maximum="10"
+                                                                        Value="{Binding Count}"
+                                                                        TickFrequency="1" IsSnapToTickEnabled="True"/>
+                                                            </Grid>
+                                                            <StackPanel Grid.Row="0" Grid.Column="4"
+                                                                        Orientation="Horizontal"
+                                                                        VerticalAlignment="Center">
+                                                                <CheckBox Content="Guarded"
+                                                                          IsChecked="{Binding IsGuarded}"
+                                                                          Margin="0,0,12,0"/>
+                                                                <TextBlock Text="Road"
+                                                                           VerticalAlignment="Center"
+                                                                           Margin="0,0,6,0"/>
+                                                                <ComboBox Width="120"
+                                                                          SelectedValuePath="Content"
+                                                                          SelectedValue="{Binding RoadDistance}">
+                                                                    <ComboBoxItem Content="Any"/>
+                                                                    <ComboBoxItem Content="Next To"/>
+                                                                    <ComboBoxItem Content="Near"/>
+                                                                    <ComboBoxItem Content="Medium"/>
+                                                                    <ComboBoxItem Content="Far"/>
+                                                                    <ComboBoxItem Content="Very Far"/>
+                                                                </ComboBox>
+                                                            </StackPanel>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+
+                                            <Rectangle Height="1" Fill="{StaticResource BrushBorder}" Margin="0,12,0,0"/>
+                                            <DockPanel Margin="0,8,0,10">
+                                                <TextBlock x:Name="TxtHeaderStorageStructures"
+                                                           Text="◆  Storage Structures"
+                                                           Style="{StaticResource SectionHeader}"
+                                                           VerticalAlignment="Center"
+                                                           Margin="0,0,10,0"
+                                                           DockPanel.Dock="Left"/>
+                                                <ComboBox x:Name="CmbStorageStructureContentPreset"
+                                                          Width="170"
+                                                          DockPanel.Dock="Left"/>
+                                                <Button x:Name="BtnAddStorageStructureContent"
+                                                        Content="Add Content"
+                                                        Width="100"
+                                                        HorizontalAlignment="Left"
+                                                        Margin="8,0,0,0"
+                                                        Style="{StaticResource ToolbarButton}"
+                                                        Click="BtnAddStorageStructureContent_Click"/>
+                                            </DockPanel>
+                                            <ItemsControl x:Name="StorageStructuresControl" ItemsSource="{Binding StorageStructureContentItems}">
                                                 <ItemsControl.ItemsPanel>
                                                     <ItemsPanelTemplate>
                                                         <StackPanel/>

--- a/Olden Era - Template Editor/MainWindow.xaml
+++ b/Olden Era - Template Editor/MainWindow.xaml
@@ -932,14 +932,14 @@
                                                     Style="{StaticResource ToolbarButton}"
                                                     Click="BtnAddTreasureContent_Click"/>
                                         </DockPanel>
-                                        <!-- Random Hires -->
-                                        <DockPanel x:Name="StickyRandomHires" Visibility="Collapsed">
-                                            <TextBlock Text="◆  Random Hires"
+                                        <!-- Unit Recruitment -->
+                                        <DockPanel x:Name="StickyUnitRecruitment" Visibility="Collapsed">
+                                            <TextBlock Text="◆  Unit Recruitment"
                                                        Style="{StaticResource SectionHeader}"
                                                        VerticalAlignment="Center"
                                                        Margin="0,0,10,0"
                                                        DockPanel.Dock="Left"/>
-                                            <ComboBox x:Name="CmbRandomHireContentPresetSticky"
+                                            <ComboBox x:Name="CmbUnitRecruitmentContentPresetSticky"
                                                       Width="170"
                                                       DockPanel.Dock="Left"/>
                                             <Button Content="Add Content"
@@ -947,7 +947,7 @@
                                                     HorizontalAlignment="Left"
                                                     Margin="8,0,0,0"
                                                     Style="{StaticResource ToolbarButton}"
-                                                    Click="BtnAddRandomHireContent_Click"/>
+                                                    Click="BtnAddUnitRecruitmentContent_Click"/>
                                         </DockPanel>
                                         <!-- Resource Banks -->
                                         <DockPanel x:Name="StickyResourceBanks" Visibility="Collapsed">
@@ -966,14 +966,14 @@
                                                     Style="{StaticResource ToolbarButton}"
                                                     Click="BtnAddResourceBankContent_Click"/>
                                         </DockPanel>
-                                        <!-- Storage Structures -->
-                                        <DockPanel x:Name="StickyStorageStructures" Visibility="Collapsed">
-                                            <TextBlock Text="◆  Storage Structures"
+                                        <!-- Utility Structures -->
+                                        <DockPanel x:Name="StickyUtilityStructures" Visibility="Collapsed">
+                                            <TextBlock Text="◆  Utility Structures"
                                                        Style="{StaticResource SectionHeader}"
                                                        VerticalAlignment="Center"
                                                        Margin="0,0,10,0"
                                                        DockPanel.Dock="Left"/>
-                                            <ComboBox x:Name="CmbStorageStructureContentPresetSticky"
+                                            <ComboBox x:Name="CmbUtilityStructureContentPresetSticky"
                                                       Width="170"
                                                       DockPanel.Dock="Left"/>
                                             <Button Content="Add Content"
@@ -981,7 +981,24 @@
                                                     HorizontalAlignment="Left"
                                                     Margin="8,0,0,0"
                                                     Style="{StaticResource ToolbarButton}"
-                                                    Click="BtnAddStorageStructureContent_Click"/>
+                                                    Click="BtnAddUtilityStructureContent_Click"/>
+                                        </DockPanel>
+                                        <!-- Hero Improvement Structures -->
+                                        <DockPanel x:Name="StickyHeroImprovementStructures" Visibility="Collapsed">
+                                            <TextBlock Text="◆  Hero Improvement Structures"
+                                                       Style="{StaticResource SectionHeader}"
+                                                       VerticalAlignment="Center"
+                                                       Margin="0,0,10,0"
+                                                       DockPanel.Dock="Left"/>
+                                            <ComboBox x:Name="CmbHeroImprovementContentPresetSticky"
+                                                      Width="170"
+                                                      DockPanel.Dock="Left"/>
+                                            <Button Content="Add Content"
+                                                    Width="100"
+                                                    HorizontalAlignment="Left"
+                                                    Margin="8,0,0,0"
+                                                    Style="{StaticResource ToolbarButton}"
+                                                    Click="BtnAddHeroImprovementContent_Click"/>
                                         </DockPanel>
                                     </Grid>
                                     <ScrollViewer x:Name="PlayerZonesScrollViewer"
@@ -1157,7 +1174,7 @@
                                                                            VerticalAlignment="Center"
                                                                            Margin="0,0,6,0"/>
                                                                 <Slider Grid.Column="1"
-                                                                        Minimum="0" Maximum="10"
+                                                                    Minimum="0" Maximum="8"
                                                                         Value="{Binding Count}"
                                                                         TickFrequency="1" IsSnapToTickEnabled="True"/>
                                                             </Grid>
@@ -1188,24 +1205,24 @@
 
                                             <Rectangle Height="1" Fill="{StaticResource BrushBorder}" Margin="0,12,0,0"/>
                                             <DockPanel Margin="0,8,0,10">
-                                                <TextBlock x:Name="TxtHeaderRandomHires"
-                                                           Text="◆  Random Hires"
+                                                <TextBlock x:Name="TxtHeaderUnitRecruitment"
+                                                       Text="◆  Unit Recruitment"
                                                            Style="{StaticResource SectionHeader}"
                                                            VerticalAlignment="Center"
                                                            Margin="0,0,10,0"
                                                            DockPanel.Dock="Left"/>
-                                                <ComboBox x:Name="CmbRandomHireContentPreset"
+                                                <ComboBox x:Name="CmbUnitRecruitmentContentPreset"
                                                           Width="170"
                                                           DockPanel.Dock="Left"/>
-                                                <Button x:Name="BtnAddRandomHireContent"
+                                                <Button x:Name="BtnAddUnitRecruitmentContent"
                                                         Content="Add Content"
                                                         Width="100"
                                                         HorizontalAlignment="Left"
                                                         Margin="8,0,0,0"
                                                         Style="{StaticResource ToolbarButton}"
-                                                        Click="BtnAddRandomHireContent_Click"/>
+                                                    Click="BtnAddUnitRecruitmentContent_Click"/>
                                             </DockPanel>
-                                            <ItemsControl x:Name="RandomHiresControl" ItemsSource="{Binding RandomHireContentItems}">
+                                                <ItemsControl x:Name="UnitRecruitmentControl" ItemsSource="{Binding UnitRecruitmentContentItems}">
                                                 <ItemsControl.ItemsPanel>
                                                     <ItemsPanelTemplate>
                                                         <StackPanel/>
@@ -1254,7 +1271,7 @@
                                                                            VerticalAlignment="Center"
                                                                            Margin="0,0,6,0"/>
                                                                 <Slider Grid.Column="1"
-                                                                        Minimum="0" Maximum="10"
+                                                                    Minimum="0" Maximum="8"
                                                                         Value="{Binding Count}"
                                                                         TickFrequency="1" IsSnapToTickEnabled="True"/>
                                                             </Grid>
@@ -1351,7 +1368,7 @@
                                                                            VerticalAlignment="Center"
                                                                            Margin="0,0,6,0"/>
                                                                 <Slider Grid.Column="1"
-                                                                        Minimum="0" Maximum="10"
+                                                                    Minimum="0" Maximum="8"
                                                                         Value="{Binding Count}"
                                                                         TickFrequency="1" IsSnapToTickEnabled="True"/>
                                                             </Grid>
@@ -1382,24 +1399,24 @@
 
                                             <Rectangle Height="1" Fill="{StaticResource BrushBorder}" Margin="0,12,0,0"/>
                                             <DockPanel Margin="0,8,0,10">
-                                                <TextBlock x:Name="TxtHeaderStorageStructures"
-                                                           Text="◆  Storage Structures"
+                                                <TextBlock x:Name="TxtHeaderUtilityStructures"
+                                                       Text="◆  Utility Structures"
                                                            Style="{StaticResource SectionHeader}"
                                                            VerticalAlignment="Center"
                                                            Margin="0,0,10,0"
                                                            DockPanel.Dock="Left"/>
-                                                <ComboBox x:Name="CmbStorageStructureContentPreset"
+                                                <ComboBox x:Name="CmbUtilityStructureContentPreset"
                                                           Width="170"
                                                           DockPanel.Dock="Left"/>
-                                                <Button x:Name="BtnAddStorageStructureContent"
+                                                <Button x:Name="BtnAddUtilityStructureContent"
                                                         Content="Add Content"
                                                         Width="100"
                                                         HorizontalAlignment="Left"
                                                         Margin="8,0,0,0"
                                                         Style="{StaticResource ToolbarButton}"
-                                                        Click="BtnAddStorageStructureContent_Click"/>
+                                                    Click="BtnAddUtilityStructureContent_Click"/>
                                             </DockPanel>
-                                            <ItemsControl x:Name="StorageStructuresControl" ItemsSource="{Binding StorageStructureContentItems}">
+                                                <ItemsControl x:Name="UtilityStructuresControl" ItemsSource="{Binding UtilityStructureContentItems}">
                                                 <ItemsControl.ItemsPanel>
                                                     <ItemsPanelTemplate>
                                                         <StackPanel/>
@@ -1448,7 +1465,104 @@
                                                                            VerticalAlignment="Center"
                                                                            Margin="0,0,6,0"/>
                                                                 <Slider Grid.Column="1"
-                                                                        Minimum="0" Maximum="10"
+                                                                    Minimum="0" Maximum="8"
+                                                                        Value="{Binding Count}"
+                                                                        TickFrequency="1" IsSnapToTickEnabled="True"/>
+                                                            </Grid>
+                                                            <StackPanel Grid.Row="0" Grid.Column="4"
+                                                                        Orientation="Horizontal"
+                                                                        VerticalAlignment="Center">
+                                                                <CheckBox Content="Guarded"
+                                                                          IsChecked="{Binding IsGuarded}"
+                                                                          Margin="0,0,12,0"/>
+                                                                <TextBlock Text="Road"
+                                                                           VerticalAlignment="Center"
+                                                                           Margin="0,0,6,0"/>
+                                                                <ComboBox Width="120"
+                                                                          SelectedValuePath="Content"
+                                                                          SelectedValue="{Binding RoadDistance}">
+                                                                    <ComboBoxItem Content="Any"/>
+                                                                    <ComboBoxItem Content="Next To"/>
+                                                                    <ComboBoxItem Content="Near"/>
+                                                                    <ComboBoxItem Content="Medium"/>
+                                                                    <ComboBoxItem Content="Far"/>
+                                                                    <ComboBoxItem Content="Very Far"/>
+                                                                </ComboBox>
+                                                            </StackPanel>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+
+                                            <Rectangle Height="1" Fill="{StaticResource BrushBorder}" Margin="0,12,0,0"/>
+                                            <DockPanel Margin="0,8,0,10">
+                                                <TextBlock x:Name="TxtHeaderHeroImprovementStructures"
+                                                       Text="◆  Hero Improvement Structures"
+                                                           Style="{StaticResource SectionHeader}"
+                                                           VerticalAlignment="Center"
+                                                           Margin="0,0,10,0"
+                                                           DockPanel.Dock="Left"/>
+                                                <ComboBox x:Name="CmbHeroImprovementContentPreset"
+                                                          Width="170"
+                                                          DockPanel.Dock="Left"/>
+                                                <Button x:Name="BtnAddHeroImprovementContent"
+                                                        Content="Add Content"
+                                                        Width="100"
+                                                        HorizontalAlignment="Left"
+                                                        Margin="8,0,0,0"
+                                                        Style="{StaticResource ToolbarButton}"
+                                                    Click="BtnAddHeroImprovementContent_Click"/>
+                                            </DockPanel>
+                                            <ItemsControl x:Name="HeroImprovementStructuresControl" ItemsSource="{Binding HeroImprovementStructureContentItems}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="{x:Type local:ZoneContentItemUI}">
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="200"/>
+                                                                <ColumnDefinition Width="8"/>
+                                                                <ColumnDefinition Width="200"/>
+                                                                <ColumnDefinition Width="8"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Grid.RowDefinitions>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="8"/>
+                                                            </Grid.RowDefinitions>
+                                                            <Grid Grid.Row="0" Grid.Column="0">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="30"/>
+                                                                    <ColumnDefinition Width="*"/>
+                                                                </Grid.ColumnDefinitions>
+                                                                <Button Grid.Column="0"
+                                                                        Content="x"
+                                                                        Width="20" Height="16"
+                                                                        Margin="4,0,0,0" Padding="0"
+                                                                        FontSize="10"
+                                                                        ToolTip="Remove content"
+                                                                        Style="{StaticResource ToolbarButton}"
+                                                                        Click="BtnRemoveZoneContent_Click"/>
+                                                                <TextBlock Grid.Column="1"
+                                                                           Text="{Binding SidMapping.Name}"
+                                                                           VerticalAlignment="Center"
+                                                                           TextTrimming="CharacterEllipsis"/>
+                                                            </Grid>
+                                                            <Grid Grid.Row="0" Grid.Column="2">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="Auto"/>
+                                                                    <ColumnDefinition Width="*"/>
+                                                                </Grid.ColumnDefinitions>
+                                                                <TextBlock Grid.Column="0"
+                                                                           Text="{Binding Count, StringFormat={}{0:0}}"
+                                                                           Style="{StaticResource ValueText}"
+                                                                           VerticalAlignment="Center"
+                                                                           Margin="0,0,6,0"/>
+                                                                <Slider Grid.Column="1"
+                                                                    Minimum="0" Maximum="8"
                                                                         Value="{Binding Count}"
                                                                         TickFrequency="1" IsSnapToTickEnabled="True"/>
                                                             </Grid>

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -111,13 +111,24 @@ namespace Olden_Era___Template_Editor
             _playerZoneMandatoryContent.treasures.Add(CreateZoneContentItem(ContentIds.RandomItemEpic));
 
             // ── Hiring — low-tier × 2 + high-tier × 1 + full pool × 1 (Kerberos + Universe blend). ──
-            _playerZoneMandatoryContent.unitRecruitment.Add(CreateZoneContentItem(IncludeListIds.RandomHiresLowTier, count: 2, isGroup: true));
-            _playerZoneMandatoryContent.unitRecruitment.Add(CreateZoneContentItem(IncludeListIds.RandomHiresHighTier, isGroup: true));
-            _playerZoneMandatoryContent.unitRecruitment.Add(CreateZoneContentItem(IncludeListIds.RandomHiresAllTier, isGroup: true));
+            _playerZoneMandatoryContent.unitRecruitment.Add(CreateZoneContentItem(IncludeListIds.RandomHiresLowTier, count: 2));
+            _playerZoneMandatoryContent.unitRecruitment.Add(CreateZoneContentItem(IncludeListIds.RandomHiresHighTier));
+            _playerZoneMandatoryContent.unitRecruitment.Add(CreateZoneContentItem(IncludeListIds.RandomHiresAllTier));
 
             // ── Guarded resource banks — tier 1 × 2 + tier 2 × 1 (Exodus pattern). ──
-            _playerZoneMandatoryContent.resourceBanks.Add(CreateZoneContentItem(IncludeListIds.ResourceBanksTier1, count: 2, isGroup: true));
-            _playerZoneMandatoryContent.resourceBanks.Add(CreateZoneContentItem(IncludeListIds.ResourceBanksTier2, isGroup: true));
+            _playerZoneMandatoryContent.resourceBanks.Add(CreateZoneContentItem(IncludeListIds.ResourceBanksTier1, count: 2));
+            _playerZoneMandatoryContent.resourceBanks.Add(CreateZoneContentItem(IncludeListIds.ResourceBanksTier2));
+
+            // ── Utility buildings (Blitz/Kerberos/Exodus pattern). ──
+            _playerZoneMandatoryContent.utilityStructures.Add(CreateZoneContentItem(ContentIds.Watchtower));
+            _playerZoneMandatoryContent.utilityStructures.Add(CreateZoneContentItem(ContentIds.Market, roadDistance: "Near"));
+            _playerZoneMandatoryContent.utilityStructures.Add(CreateZoneContentItem(ContentIds.ManaWell, roadDistance: "Near"));
+            
+            // ── Hero training — tier-2 stat building (fort/university/orb_observatory) ──
+            //    + uncommon hero bank (university/wise_owl/tree_of_knowledge) (Blitz/Exodus pattern).
+            _playerZoneMandatoryContent.heroImprovementStructures.Add(CreateZoneContentItem(IncludeListIds.HeroStatsAndSkillsTier2));
+            _playerZoneMandatoryContent.heroImprovementStructures.Add(CreateZoneContentItem(IncludeListIds.HeroImprovementUncommon));
+
         }
 
         private void PopulateZoneContentMenu(ComboBox comboBox, ComboBox comboBoxSticky, List<SidMapping> contentGroup)
@@ -913,14 +924,7 @@ namespace Olden_Era___Template_Editor
             if (mapping == null)
                 return;
             
-            if(mapping.Sid.ToLower().Contains(IncludeListIds.Identifier)) 
-            {
-                collection.Add(CreateZoneContentItem(mapping, isGroup: true));
-            }
-            else
-            {
-                collection.Add(CreateZoneContentItem(mapping, isGroup: false));
-            }
+            collection.Add(CreateZoneContentItem(mapping));
             MarkDirty();
         }
 
@@ -994,8 +998,14 @@ namespace Olden_Era___Template_Editor
             MarkDirty();
         }
 
-        private static ZoneContentItemUI CreateZoneContentItem(SidMapping preset, int count = 1, bool isGuarded = true, bool nearCastle = false, string roadDistance = "Any", bool isGroup = false)
+        private static ZoneContentItemUI CreateZoneContentItem(SidMapping preset, int count = 1, bool isGuarded = true, bool nearCastle = false, string roadDistance = "Any")
         {
+            bool isGroup = false;
+            if(preset.Sid.ToLower().Contains(IncludeListIds.Identifier))
+            {
+                // Mark the content item as an include list group for proper generation.
+                isGroup = true;
+            }
             return new ZoneContentItemUI
             {
                 SidMapping = preset,
@@ -1462,6 +1472,7 @@ namespace Olden_Era___Template_Editor
 
             foreach (var contentItem in contentItems)
             {
+                /* We need to parse the "real" content item data to get the SID for our mapping. Grouped entries from IncludeListIds have their "sid" as name of the include list. */
                 bool isGroup = contentItem.IncludeLists is { Count: > 0 };
                 string? sid = isGroup
                     ? contentItem.IncludeLists![0]
@@ -1481,7 +1492,6 @@ namespace Olden_Era___Template_Editor
 
                 var key = new PlayerZoneContentKey(
                     sidMapping.Sid,
-                    isGroup,
                     isMine,
                     isGuarded,
                     nearCastle,
@@ -1508,8 +1518,7 @@ namespace Olden_Era___Template_Editor
                     count: kvp.Value,
                     isGuarded: kvp.Key.IsGuarded,
                     nearCastle: kvp.Key.NearCastle,
-                    roadDistance: kvp.Key.RoadDistance,
-                    isGroup: kvp.Key.IsGroup);
+                    roadDistance: kvp.Key.RoadDistance);
 
                 if (IsContentItemGroupSid(kvp.Key.Sid, ContentItemGroup.Mines))
                 {
@@ -1572,7 +1581,6 @@ namespace Olden_Era___Template_Editor
 
         private readonly record struct PlayerZoneContentKey(
             string Sid,
-            bool IsGroup,
             bool IsMine,
             bool IsGuarded,
             bool NearCastle,

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -904,14 +904,6 @@ namespace Olden_Era___Template_Editor
                 : Visibility.Collapsed;
         }
 
-        private void UpdateBalancedZonePlacementDescVisibility()
-        {
-            if (TxtBalancedZonePlacementDesc == null || ChkBalancedZonePlacement == null) return;
-            TxtBalancedZonePlacementDesc.Visibility = ChkBalancedZonePlacement.IsChecked == true
-                ? Visibility.Visible
-                : Visibility.Collapsed;
-        }
-
         private void AddZoneContentItemFromName(ObservableCollection<ZoneContentItemUI> collection, string name)
         {
             if (string.IsNullOrWhiteSpace(name))

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -37,10 +37,8 @@ namespace Olden_Era___Template_Editor
         private bool _isDirty = false;
         private bool _isRefreshingMapSizes = false;
         private string _baseTitle = string.Empty;
-        private readonly ObservableCollection<ZoneContentItemUI> _zoneContentMines = new();
-        private readonly ObservableCollection<ZoneContentItemUI> _treasureContentItems = new();
-        private readonly ObservableCollection<ZoneContentItemUI> _randomHires = new();
-        private readonly ObservableCollection<ZoneContentItemUI> _resourceBanks = new();
+
+        private ZoneMandatoryContent _playerZoneMandatoryContent = new();
 
         private static readonly (MapTopology Topology, string Label, string Description)[] TopologyOptions =
         [
@@ -82,10 +80,11 @@ namespace Olden_Era___Template_Editor
             InitializeDefaultPlayerZoneContents();
             DataContext = new
             {
-                MineContentItems = _zoneContentMines,
-                TreasureContentItems = _treasureContentItems,
-                RandomHireContentItems = _randomHires,
-                ResourceBankContentItems = _resourceBanks
+                MineContentItems = _playerZoneMandatoryContent.mines,
+                TreasureContentItems = _playerZoneMandatoryContent.treasures,
+                RandomHireContentItems = _playerZoneMandatoryContent.randomHires,
+                ResourceBankContentItems = _playerZoneMandatoryContent.resourceBanks,
+                StorageStructureContentItems = _playerZoneMandatoryContent.storageStructures
             };
             // Fire-and-forget background update check — never blocks the UI.
             _ = CheckForUpdateAsync(version);
@@ -97,81 +96,56 @@ namespace Olden_Era___Template_Editor
         private void InitializeDefaultPlayerZoneContents()
         {
             // ── Basic mines — guarded, anchored near the player castle (every template). ──
-            _zoneContentMines.Add(CreateZoneContentItem(ContentIds.MineWood, isGuarded: true, nearCastle: true, roadDistance: "Near"));
-            _zoneContentMines.Add(CreateZoneContentItem(ContentIds.MineOre, isGuarded: true, nearCastle: true, roadDistance: "Near"));
+            _playerZoneMandatoryContent.mines.Add(CreateZoneContentItem(ContentIds.MineWood, nearCastle: true, roadDistance: "Near"));
+            _playerZoneMandatoryContent.mines.Add(CreateZoneContentItem(ContentIds.MineOre, nearCastle: true, roadDistance: "Near"));
             // ── Gold mine (Exodus/Staircase/Yin Yang pattern). ──
-            _zoneContentMines.Add(CreateZoneContentItem(ContentIds.MineGold, isGuarded: true, roadDistance: "Near"));
+            _playerZoneMandatoryContent.mines.Add(CreateZoneContentItem(ContentIds.MineGold, roadDistance: "Near"));
             // ── Rare mines spread along roads (Exodus/Staircase/Yin Yang pattern). ──
-            _zoneContentMines.Add(CreateZoneContentItem(ContentIds.MineCrystals, isGuarded: true, roadDistance: "Next To"));
-            _zoneContentMines.Add(CreateZoneContentItem(ContentIds.MineMercury, isGuarded: true, roadDistance: "Next To"));
-            _zoneContentMines.Add(CreateZoneContentItem(ContentIds.MineGemstones, isGuarded: true, roadDistance: "Next To"));
-            _zoneContentMines.Add(CreateZoneContentItem(ContentIds.AlchemyLab, isGuarded: true, roadDistance: "Next To"));
+            _playerZoneMandatoryContent.mines.Add(CreateZoneContentItem(ContentIds.MineCrystals, roadDistance: "Next To"));
+            _playerZoneMandatoryContent.mines.Add(CreateZoneContentItem(ContentIds.MineMercury, roadDistance: "Next To"));
+            _playerZoneMandatoryContent.mines.Add(CreateZoneContentItem(ContentIds.MineGemstones, roadDistance: "Next To"));
+            _playerZoneMandatoryContent.mines.Add(CreateZoneContentItem(ContentIds.AlchemyLab, roadDistance: "Next To"));
             // ── Loot — epic items + army pandora (Exodus/Blitz pattern). ──
-            _treasureContentItems.Add(CreateZoneContentItem(ContentIds.PandoraBox, isGuarded: true));
-            _treasureContentItems.Add(CreateZoneContentItem(ContentIds.RandomItemEpic, isGuarded: true));
+            _playerZoneMandatoryContent.treasures.Add(CreateZoneContentItem(ContentIds.PandoraBox));
+            _playerZoneMandatoryContent.treasures.Add(CreateZoneContentItem(ContentIds.RandomItemEpic));
 
             // ── Hiring — low-tier × 2 + high-tier × 1 + full pool × 1 (Kerberos + Universe blend). ──
-            _randomHires.Add(CreateZoneContentItem(IncludeListIds.RandomHiresLowTier, isGuarded: true, count: 2, isGroup: true));
-            _randomHires.Add(CreateZoneContentItem(IncludeListIds.RandomHiresHighTier, isGuarded: true, isGroup: true));
-            _randomHires.Add(CreateZoneContentItem(IncludeListIds.RandomHiresAllTier, isGuarded: true, isGroup: true));
+            _playerZoneMandatoryContent.randomHires.Add(CreateZoneContentItem(IncludeListIds.RandomHiresLowTier, count: 2, isGroup: true));
+            _playerZoneMandatoryContent.randomHires.Add(CreateZoneContentItem(IncludeListIds.RandomHiresHighTier, isGroup: true));
+            _playerZoneMandatoryContent.randomHires.Add(CreateZoneContentItem(IncludeListIds.RandomHiresAllTier, isGroup: true));
 
             // ── Guarded resource banks — tier 1 × 2 + tier 2 × 1 (Exodus pattern). ──
-            _resourceBanks.Add(CreateZoneContentItem(IncludeListIds.ResourceBanksTier1, isGuarded: true, count: 2, isGroup: true));
-            _resourceBanks.Add(CreateZoneContentItem(IncludeListIds.ResourceBanksTier2, isGuarded: true, isGroup: true));
+            _playerZoneMandatoryContent.resourceBanks.Add(CreateZoneContentItem(IncludeListIds.ResourceBanksTier1, count: 2, isGroup: true));
+            _playerZoneMandatoryContent.resourceBanks.Add(CreateZoneContentItem(IncludeListIds.ResourceBanksTier2, isGroup: true));
         }
+
+        private void PopulateZoneContentMenu(ComboBox comboBox, ComboBox comboBoxSticky, List<SidMapping> contentGroup)
+        {
+            var names = new List<string>();
+            foreach (SidMapping sidMapping in contentGroup)
+            {
+                names.Add(sidMapping.Name);
+            }
+            comboBox.ItemsSource = names;
+            comboBox.SelectedIndex = 0;
+            comboBoxSticky.ItemsSource = names;
+            comboBoxSticky.SelectedIndex = 0;
+            comboBox.SelectionChanged       += (_, _) => comboBoxSticky.SelectedIndex = comboBox.SelectedIndex;
+            comboBoxSticky.SelectionChanged += (_, _) => comboBox.SelectedIndex       = comboBoxSticky.SelectedIndex;
+        }
+
         private void InitializeZoneContentPresets()
         {
             /* Populate the Mines dropdown menu */
-            var mineNames = new List<string>();
-            foreach (SidMapping sidMapping in ContentItemGroup.Mines)
-            {
-                mineNames.Add(sidMapping.Name);
-            }
-            CmbZoneContentPreset.ItemsSource = mineNames;
-            CmbZoneContentPreset.SelectedIndex = 0;
-            CmbZoneContentPresetSticky.ItemsSource = mineNames;
-            CmbZoneContentPresetSticky.SelectedIndex = 0;
-            CmbZoneContentPreset.SelectionChanged       += (_, _) => CmbZoneContentPresetSticky.SelectedIndex = CmbZoneContentPreset.SelectedIndex;
-            CmbZoneContentPresetSticky.SelectionChanged += (_, _) => CmbZoneContentPreset.SelectedIndex       = CmbZoneContentPresetSticky.SelectedIndex;
-
+            PopulateZoneContentMenu(CmbZoneContentPreset, CmbZoneContentPresetSticky, ContentItemGroup.Mines);
             /* Populate the Treasures dropdown menu */
-            var treasurePresetNames = new List<string>();
-            foreach (SidMapping sidMapping in ContentItemGroup.Treasures)
-            {
-                treasurePresetNames.Add(sidMapping.Name);
-            }
-            CmbTreasureContentPreset.ItemsSource = treasurePresetNames;
-            CmbTreasureContentPreset.SelectedIndex = 0;
-            CmbTreasureContentPresetSticky.ItemsSource = treasurePresetNames;
-            CmbTreasureContentPresetSticky.SelectedIndex = 0;
-            CmbTreasureContentPreset.SelectionChanged       += (_, _) => CmbTreasureContentPresetSticky.SelectedIndex = CmbTreasureContentPreset.SelectedIndex;
-            CmbTreasureContentPresetSticky.SelectionChanged += (_, _) => CmbTreasureContentPreset.SelectedIndex       = CmbTreasureContentPresetSticky.SelectedIndex;
-
+            PopulateZoneContentMenu(CmbTreasureContentPreset, CmbTreasureContentPresetSticky, ContentItemGroup.Treasures);
             /* Populate the Random Hires dropdown menu */
-            var randomHirePresetNames = new List<string>();
-            foreach (SidMapping sidMapping in ContentItemGroup.HireBuildings)
-            {
-                randomHirePresetNames.Add(sidMapping.Name);
-            }
-            CmbRandomHireContentPreset.ItemsSource = randomHirePresetNames;
-            CmbRandomHireContentPreset.SelectedIndex = 0;
-            CmbRandomHireContentPresetSticky.ItemsSource = randomHirePresetNames;
-            CmbRandomHireContentPresetSticky.SelectedIndex = 0;
-            CmbRandomHireContentPreset.SelectionChanged       += (_, _) => CmbRandomHireContentPresetSticky.SelectedIndex = CmbRandomHireContentPreset.SelectedIndex;
-            CmbRandomHireContentPresetSticky.SelectionChanged += (_, _) => CmbRandomHireContentPreset.SelectedIndex       = CmbRandomHireContentPresetSticky.SelectedIndex;
-
+            PopulateZoneContentMenu(CmbRandomHireContentPreset, CmbRandomHireContentPresetSticky, ContentItemGroup.HireStructures);
              /* Populate the Resource Banks dropdown menu */
-            var resourceBankPresetNames = new List<string>();
-            foreach (SidMapping sidMapping in ContentItemGroup.ResourceBanks)
-            {
-                resourceBankPresetNames.Add(sidMapping.Name);
-            }
-            CmbResourceBankContentPreset.ItemsSource = resourceBankPresetNames;
-            CmbResourceBankContentPreset.SelectedIndex = 0;
-            CmbResourceBankContentPresetSticky.ItemsSource = resourceBankPresetNames;
-            CmbResourceBankContentPresetSticky.SelectedIndex = 0;
-            CmbResourceBankContentPreset.SelectionChanged       += (_, _) => CmbResourceBankContentPresetSticky.SelectedIndex = CmbResourceBankContentPreset.SelectedIndex;
-            CmbResourceBankContentPresetSticky.SelectionChanged += (_, _) => CmbResourceBankContentPreset.SelectedIndex       = CmbResourceBankContentPresetSticky.SelectedIndex;
+            PopulateZoneContentMenu(CmbResourceBankContentPreset, CmbResourceBankContentPresetSticky, ContentItemGroup.ResourceBanks);
+            /* Populate the Storage Structures dropdown menu */
+            PopulateZoneContentMenu(CmbStorageStructureContentPreset, CmbStorageStructureContentPresetSticky, ContentItemGroup.StorageStructures);
         }
 
         private async Task CheckForUpdateAsync(Version? currentVersion)
@@ -762,19 +736,32 @@ namespace Olden_Era___Template_Editor
                 : Visibility.Collapsed;
         }
 
+        private void AddZoneContentItemFromName(ObservableCollection<ZoneContentItemUI> collection, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return;
+
+            SidMapping? mapping = GlobalContent.GetByName(name);
+            if (mapping == null)
+                return;
+            
+            if(mapping.Sid.ToLower().Contains(IncludeListIds.Identifier)) 
+            {
+                collection.Add(CreateZoneContentItem(mapping, isGroup: true));
+            }
+            else
+            {
+                collection.Add(CreateZoneContentItem(mapping, isGroup: false));
+            }
+            MarkDirty();
+        }
+
         private void BtnAddMineContent_Click(object sender, RoutedEventArgs e)
         {
             if (!IsInitialized) return;
 
             string name = CmbZoneContentPreset.SelectedItem as string ?? string.Empty;
-            if (string.IsNullOrWhiteSpace(name))
-                return;
-
-            SidMapping? preset = GlobalContent.GetByName(name);
-            if (preset == null)
-                return;
-            _zoneContentMines.Add(CreateZoneContentItem(preset));
-            MarkDirty();
+            AddZoneContentItemFromName(_playerZoneMandatoryContent.mines, name);
         }
 
         private void BtnAddTreasureContent_Click(object sender, RoutedEventArgs e)
@@ -782,53 +769,31 @@ namespace Olden_Era___Template_Editor
             if (!IsInitialized) return;
 
             string name = CmbTreasureContentPreset.SelectedItem as string ?? string.Empty;
-            if (string.IsNullOrWhiteSpace(name))
-                return;
-
-            SidMapping? preset = GlobalContent.GetByName(name);
-            if (preset == null)
-                return;
-            _treasureContentItems.Add(CreateZoneContentItem(preset));
-            MarkDirty();
+            AddZoneContentItemFromName(_playerZoneMandatoryContent.treasures, name);
         }
 
         private void BtnAddRandomHireContent_Click(object sender, RoutedEventArgs e)
         {
             if (!IsInitialized) return;
 
-            string name = (FindName("CmbRandomHireContentPreset") as ComboBox)?.SelectedItem as string ?? string.Empty;
-            if (string.IsNullOrWhiteSpace(name))
-                return;
-
-            SidMapping? preset = GlobalContent.GetByName(name);
-            if (preset == null)
-                return;
-
-            if(preset.Sid.ToLower().Contains("content")) 
-            {
-                _randomHires.Add(CreateZoneContentItem(preset, isGroup: true));
-            }
-            else
-            {
-                _randomHires.Add(CreateZoneContentItem(preset, isGroup: false));
-            }
-            MarkDirty();
+            string name = (FindName("CmbRandomHireContentPreset") as ComboBox)?.SelectedItem as string ?? string.Empty;      
+            AddZoneContentItemFromName(_playerZoneMandatoryContent.randomHires, name);
         }
 
         private void BtnAddResourceBankContent_Click(object sender, RoutedEventArgs e)
         {
             if (!IsInitialized) return;
 
-            string name = (FindName("CmbResourceBankContentPreset") as ComboBox)?.SelectedItem as string ?? string.Empty;
-            if (string.IsNullOrWhiteSpace(name))
-                return;
+            string name = (FindName("CmbResourceBankContentPreset") as ComboBox)?.SelectedItem as string ?? string.Empty; 
+            AddZoneContentItemFromName(_playerZoneMandatoryContent.resourceBanks, name);   
+        }
 
-            SidMapping? preset = GlobalContent.GetByName(name);
-            if (preset == null)
-                return;
+        private void BtnAddStorageStructureContent_Click(object sender, RoutedEventArgs e)
+        {
+            if (!IsInitialized) return;
 
-            _resourceBanks.Add(CreateZoneContentItem(preset, isGroup: true));
-            MarkDirty();
+            string name = (FindName("CmbStorageStructureContentPreset") as ComboBox)?.SelectedItem as string ?? string.Empty;
+            AddZoneContentItemFromName(_playerZoneMandatoryContent.storageStructures, name);
         }
 
         private void BtnRemoveZoneContent_Click(object sender, RoutedEventArgs e)
@@ -837,11 +802,9 @@ namespace Olden_Era___Template_Editor
 
             if (sender is not Button button || button.DataContext is not ZoneContentItemUI item)
                 return;
-
-            if (_zoneContentMines.Remove(item)
-                || _treasureContentItems.Remove(item)
-                || _randomHires.Remove(item)
-                || _resourceBanks.Remove(item))
+            
+            
+            if(_playerZoneMandatoryContent.Remove(item))
                 MarkDirty();
         }
 
@@ -849,16 +812,13 @@ namespace Olden_Era___Template_Editor
         {
             if (!IsInitialized) return;
 
-            _zoneContentMines.Clear();
-            _treasureContentItems.Clear();
-            _randomHires.Clear();
-            _resourceBanks.Clear();
+            _playerZoneMandatoryContent.Clear();
 
             InitializeDefaultPlayerZoneContents();
             MarkDirty();
         }
 
-        private static ZoneContentItemUI CreateZoneContentItem(SidMapping preset, int count = 1, bool isGuarded = false, bool nearCastle = false, string roadDistance = "Any", bool isGroup = false)
+        private static ZoneContentItemUI CreateZoneContentItem(SidMapping preset, int count = 1, bool isGuarded = true, bool nearCastle = false, string roadDistance = "Any", bool isGroup = false)
         {
             return new ZoneContentItemUI
             {
@@ -1252,10 +1212,7 @@ namespace Olden_Era___Template_Editor
         {
             var result = new List<ContentItem>();
 
-            foreach (var item in _zoneContentMines
-                         .Concat(_treasureContentItems)
-                         .Concat(_randomHires)
-                         .Concat(_resourceBanks))
+            foreach (var item in _playerZoneMandatoryContent.AllItems)
             {
                 /* Some initial sanity checks*/
                 if (item.Count <= 0) continue;
@@ -1297,7 +1254,7 @@ namespace Olden_Era___Template_Editor
                         .Create(item.SidMapping.Sid)
                         .Guarded(item.IsGuarded);
                     
-                    if(_zoneContentMines.Contains(item))
+                    if(_playerZoneMandatoryContent.mines.Contains(item))
                         builder.Mine();
                     
                     if (item.NearCastle)
@@ -1314,12 +1271,10 @@ namespace Olden_Era___Template_Editor
             return result;
         }
 
+        /* Loading settings from file to restore UI state */
         private void ApplyPlayerZoneMandatoryContentFromSettings(List<ContentItem>? contentItems)
         {
-            _zoneContentMines.Clear();
-            _treasureContentItems.Clear();
-            _randomHires.Clear();
-            _resourceBanks.Clear();
+            _playerZoneMandatoryContent.Clear();
 
             if (contentItems is null || contentItems.Count == 0)
             {
@@ -1382,19 +1337,23 @@ namespace Olden_Era___Template_Editor
 
                 if (kvp.Key.IsMine)
                 {
-                    _zoneContentMines.Add(uiItem);
+                    _playerZoneMandatoryContent.mines.Add(uiItem);
                 }
                 else if (IsRandomHireSid(kvp.Key.Sid))
                 {
-                    _randomHires.Add(uiItem);
+                    _playerZoneMandatoryContent.randomHires.Add(uiItem);
                 }
                 else if (IsResourceBankSid(kvp.Key.Sid))
                 {
-                    _resourceBanks.Add(uiItem);
+                    _playerZoneMandatoryContent.resourceBanks.Add(uiItem);
+                }
+                else if (IsStorageStructureSid(kvp.Key.Sid))
+                {
+                    _playerZoneMandatoryContent.storageStructures.Add(uiItem);
                 }
                 else
                 {
-                    _treasureContentItems.Add(uiItem);
+                    _playerZoneMandatoryContent.treasures.Add(uiItem);
                 }
             }
         }
@@ -1428,15 +1387,13 @@ namespace Olden_Era___Template_Editor
             => Math.Abs(min - preset.Min) < 0.0001 && Math.Abs(max - preset.Max) < 0.0001;
 
         private static bool IsRandomHireSid(string sid)
-            => ContentItemGroup.HireBuildings.Any(item => string.Equals(item.Sid, sid, StringComparison.OrdinalIgnoreCase))
-                || string.Equals(IncludeListIds.RandomHiresLowTier.Sid, sid, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(IncludeListIds.RandomHiresHighTier.Sid, sid, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(IncludeListIds.RandomHiresAllTier.Sid, sid, StringComparison.OrdinalIgnoreCase);
+            => ContentItemGroup.HireStructures.Any(item => string.Equals(item.Sid, sid, StringComparison.OrdinalIgnoreCase));
 
         private static bool IsResourceBankSid(string sid)
-            => ContentItemGroup.ResourceBanks.Any(item => string.Equals(item.Sid, sid, StringComparison.OrdinalIgnoreCase))
-                || string.Equals(IncludeListIds.ResourceBanksTier1.Sid, sid, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(IncludeListIds.ResourceBanksTier2.Sid, sid, StringComparison.OrdinalIgnoreCase);
+            => ContentItemGroup.ResourceBanks.Any(item => string.Equals(item.Sid, sid, StringComparison.OrdinalIgnoreCase));
+
+        private static bool IsStorageStructureSid(string sid)
+            => ContentItemGroup.StorageStructures.Any(item => string.Equals(item.Sid, sid, StringComparison.OrdinalIgnoreCase));
 
         private readonly record struct PlayerZoneContentKey(
             string Sid,
@@ -1540,6 +1497,7 @@ namespace Olden_Era___Template_Editor
             // whose top edge has scrolled above the viewport top.
             var headers = new[]
             {
+                (Element: TxtHeaderStorageStructures, Sticky: StickyStorageStructures),
                 (Element: TxtHeaderResourceBanks, Sticky: StickyResourceBanks),
                 (Element: TxtHeaderRandomHires,   Sticky: StickyRandomHires),
                 (Element: TxtHeaderTreasures,     Sticky: StickyTreasures),
@@ -1569,6 +1527,7 @@ namespace Olden_Era___Template_Editor
             StickyTreasures.Visibility     = Visibility.Collapsed;
             StickyRandomHires.Visibility   = Visibility.Collapsed;
             StickyResourceBanks.Visibility = Visibility.Collapsed;
+            StickyStorageStructures.Visibility = Visibility.Collapsed;
             active.Visibility              = Visibility.Visible;
         }
 

--- a/Olden Era - Template Editor/MainWindow.xaml.cs
+++ b/Olden Era - Template Editor/MainWindow.xaml.cs
@@ -82,9 +82,10 @@ namespace Olden_Era___Template_Editor
             {
                 MineContentItems = _playerZoneMandatoryContent.mines,
                 TreasureContentItems = _playerZoneMandatoryContent.treasures,
-                RandomHireContentItems = _playerZoneMandatoryContent.randomHires,
+                UnitRecruitmentContentItems = _playerZoneMandatoryContent.unitRecruitment,
                 ResourceBankContentItems = _playerZoneMandatoryContent.resourceBanks,
-                StorageStructureContentItems = _playerZoneMandatoryContent.storageStructures
+                UtilityStructureContentItems = _playerZoneMandatoryContent.utilityStructures,
+                HeroImprovementStructureContentItems = _playerZoneMandatoryContent.heroImprovementStructures
             };
             // Fire-and-forget background update check — never blocks the UI.
             _ = CheckForUpdateAsync(version);
@@ -110,9 +111,9 @@ namespace Olden_Era___Template_Editor
             _playerZoneMandatoryContent.treasures.Add(CreateZoneContentItem(ContentIds.RandomItemEpic));
 
             // ── Hiring — low-tier × 2 + high-tier × 1 + full pool × 1 (Kerberos + Universe blend). ──
-            _playerZoneMandatoryContent.randomHires.Add(CreateZoneContentItem(IncludeListIds.RandomHiresLowTier, count: 2, isGroup: true));
-            _playerZoneMandatoryContent.randomHires.Add(CreateZoneContentItem(IncludeListIds.RandomHiresHighTier, isGroup: true));
-            _playerZoneMandatoryContent.randomHires.Add(CreateZoneContentItem(IncludeListIds.RandomHiresAllTier, isGroup: true));
+            _playerZoneMandatoryContent.unitRecruitment.Add(CreateZoneContentItem(IncludeListIds.RandomHiresLowTier, count: 2, isGroup: true));
+            _playerZoneMandatoryContent.unitRecruitment.Add(CreateZoneContentItem(IncludeListIds.RandomHiresHighTier, isGroup: true));
+            _playerZoneMandatoryContent.unitRecruitment.Add(CreateZoneContentItem(IncludeListIds.RandomHiresAllTier, isGroup: true));
 
             // ── Guarded resource banks — tier 1 × 2 + tier 2 × 1 (Exodus pattern). ──
             _playerZoneMandatoryContent.resourceBanks.Add(CreateZoneContentItem(IncludeListIds.ResourceBanksTier1, count: 2, isGroup: true));
@@ -140,12 +141,14 @@ namespace Olden_Era___Template_Editor
             PopulateZoneContentMenu(CmbZoneContentPreset, CmbZoneContentPresetSticky, ContentItemGroup.Mines);
             /* Populate the Treasures dropdown menu */
             PopulateZoneContentMenu(CmbTreasureContentPreset, CmbTreasureContentPresetSticky, ContentItemGroup.Treasures);
-            /* Populate the Random Hires dropdown menu */
-            PopulateZoneContentMenu(CmbRandomHireContentPreset, CmbRandomHireContentPresetSticky, ContentItemGroup.HireStructures);
+            /* Populate the Unit Recruitment dropdown menu */
+            PopulateZoneContentMenu(CmbUnitRecruitmentContentPreset, CmbUnitRecruitmentContentPresetSticky, ContentItemGroup.UnitRecruitment);
              /* Populate the Resource Banks dropdown menu */
             PopulateZoneContentMenu(CmbResourceBankContentPreset, CmbResourceBankContentPresetSticky, ContentItemGroup.ResourceBanks);
-            /* Populate the Storage Structures dropdown menu */
-            PopulateZoneContentMenu(CmbStorageStructureContentPreset, CmbStorageStructureContentPresetSticky, ContentItemGroup.StorageStructures);
+            /* Populate the Utility Structures dropdown menu */
+            PopulateZoneContentMenu(CmbUtilityStructureContentPreset, CmbUtilityStructureContentPresetSticky, ContentItemGroup.UtilityStructures);
+            /* Populate the Hero Improvement Structures dropdown menu */
+            PopulateZoneContentMenu(CmbHeroImprovementContentPreset, CmbHeroImprovementContentPresetSticky, ContentItemGroup.HeroImprovementStructures);
         }
 
         private async Task CheckForUpdateAsync(Version? currentVersion)
@@ -937,12 +940,12 @@ namespace Olden_Era___Template_Editor
             AddZoneContentItemFromName(_playerZoneMandatoryContent.treasures, name);
         }
 
-        private void BtnAddRandomHireContent_Click(object sender, RoutedEventArgs e)
+        private void BtnAddUnitRecruitmentContent_Click(object sender, RoutedEventArgs e)
         {
             if (!IsInitialized) return;
 
-            string name = (FindName("CmbRandomHireContentPreset") as ComboBox)?.SelectedItem as string ?? string.Empty;      
-            AddZoneContentItemFromName(_playerZoneMandatoryContent.randomHires, name);
+            string name = (FindName("CmbUnitRecruitmentContentPreset") as ComboBox)?.SelectedItem as string ?? string.Empty;
+            AddZoneContentItemFromName(_playerZoneMandatoryContent.unitRecruitment, name);
         }
 
         private void BtnAddResourceBankContent_Click(object sender, RoutedEventArgs e)
@@ -953,12 +956,20 @@ namespace Olden_Era___Template_Editor
             AddZoneContentItemFromName(_playerZoneMandatoryContent.resourceBanks, name);   
         }
 
-        private void BtnAddStorageStructureContent_Click(object sender, RoutedEventArgs e)
+        private void BtnAddUtilityStructureContent_Click(object sender, RoutedEventArgs e)
         {
             if (!IsInitialized) return;
 
-            string name = (FindName("CmbStorageStructureContentPreset") as ComboBox)?.SelectedItem as string ?? string.Empty;
-            AddZoneContentItemFromName(_playerZoneMandatoryContent.storageStructures, name);
+            string name = (FindName("CmbUtilityStructureContentPreset") as ComboBox)?.SelectedItem as string ?? string.Empty;
+            AddZoneContentItemFromName(_playerZoneMandatoryContent.utilityStructures, name);
+        }
+
+        private void BtnAddHeroImprovementContent_Click(object sender, RoutedEventArgs e)
+        {
+            if (!IsInitialized) return;
+
+            string name = (FindName("CmbHeroImprovementContentPreset") as ComboBox)?.SelectedItem as string ?? string.Empty;
+            AddZoneContentItemFromName(_playerZoneMandatoryContent.heroImprovementStructures, name);
         }
 
         private void BtnRemoveZoneContent_Click(object sender, RoutedEventArgs e)
@@ -1446,7 +1457,7 @@ namespace Olden_Era___Template_Editor
                 InitializeDefaultPlayerZoneContents();
                 return;
             }
-
+            /* Categorize the content items */
             var groupedItems = new Dictionary<PlayerZoneContentKey, int>();
 
             foreach (var contentItem in contentItems)
@@ -1485,7 +1496,7 @@ namespace Olden_Era___Template_Editor
                     groupedItems[key] = 1;
                 }
             }
-
+            /* Add categorized content items to proper content lists */
             foreach (var kvp in groupedItems)
             {
                 SidMapping? sidMapping = GlobalContent.GetBySid(kvp.Key.Sid);
@@ -1500,23 +1511,27 @@ namespace Olden_Era___Template_Editor
                     roadDistance: kvp.Key.RoadDistance,
                     isGroup: kvp.Key.IsGroup);
 
-                if (kvp.Key.IsMine)
+                if (IsContentItemGroupSid(kvp.Key.Sid, ContentItemGroup.Mines))
                 {
                     _playerZoneMandatoryContent.mines.Add(uiItem);
                 }
-                else if (IsRandomHireSid(kvp.Key.Sid))
+                else if (IsContentItemGroupSid(kvp.Key.Sid, ContentItemGroup.UnitRecruitment))
                 {
-                    _playerZoneMandatoryContent.randomHires.Add(uiItem);
+                    _playerZoneMandatoryContent.unitRecruitment.Add(uiItem);
                 }
-                else if (IsResourceBankSid(kvp.Key.Sid))
+                else if (IsContentItemGroupSid(kvp.Key.Sid, ContentItemGroup.ResourceBanks))
                 {
                     _playerZoneMandatoryContent.resourceBanks.Add(uiItem);
                 }
-                else if (IsStorageStructureSid(kvp.Key.Sid))
+                else if (IsContentItemGroupSid(kvp.Key.Sid, ContentItemGroup.UtilityStructures))
                 {
-                    _playerZoneMandatoryContent.storageStructures.Add(uiItem);
+                    _playerZoneMandatoryContent.utilityStructures.Add(uiItem);
                 }
-                else
+                else if (IsContentItemGroupSid(kvp.Key.Sid, ContentItemGroup.HeroImprovementStructures))
+                {
+                    _playerZoneMandatoryContent.heroImprovementStructures.Add(uiItem);
+                }
+                else if(IsContentItemGroupSid(kvp.Key.Sid, ContentItemGroup.Treasures))
                 {
                     _playerZoneMandatoryContent.treasures.Add(uiItem);
                 }
@@ -1550,15 +1565,10 @@ namespace Olden_Era___Template_Editor
 
         private static bool IsDistance(double min, double max, DistanceVariation preset)
             => Math.Abs(min - preset.Min) < 0.0001 && Math.Abs(max - preset.Max) < 0.0001;
-
-        private static bool IsRandomHireSid(string sid)
-            => ContentItemGroup.HireStructures.Any(item => string.Equals(item.Sid, sid, StringComparison.OrdinalIgnoreCase));
-
-        private static bool IsResourceBankSid(string sid)
-            => ContentItemGroup.ResourceBanks.Any(item => string.Equals(item.Sid, sid, StringComparison.OrdinalIgnoreCase));
-
-        private static bool IsStorageStructureSid(string sid)
-            => ContentItemGroup.StorageStructures.Any(item => string.Equals(item.Sid, sid, StringComparison.OrdinalIgnoreCase));
+        
+        /* Helper function for checking if a SID belongs to a content item group */
+        private static bool IsContentItemGroupSid(string sid, List<SidMapping> groupItems)
+            => groupItems.Any(item => string.Equals(item.Sid, sid, StringComparison.OrdinalIgnoreCase));
 
         private readonly record struct PlayerZoneContentKey(
             string Sid,
@@ -1662,9 +1672,10 @@ namespace Olden_Era___Template_Editor
             // whose top edge has scrolled above the viewport top.
             var headers = new[]
             {
-                (Element: TxtHeaderStorageStructures, Sticky: StickyStorageStructures),
+                (Element: TxtHeaderHeroImprovementStructures, Sticky: StickyHeroImprovementStructures),
+                (Element: TxtHeaderUtilityStructures, Sticky: StickyUtilityStructures),
                 (Element: TxtHeaderResourceBanks, Sticky: StickyResourceBanks),
-                (Element: TxtHeaderRandomHires,   Sticky: StickyRandomHires),
+                (Element: TxtHeaderUnitRecruitment, Sticky: StickyUnitRecruitment),
                 (Element: TxtHeaderTreasures,     Sticky: StickyTreasures),
                 (Element: TxtHeaderMines,         Sticky: StickyMines),
             };
@@ -1690,9 +1701,10 @@ namespace Olden_Era___Template_Editor
             StickyHeaderPanel.Visibility   = Visibility.Visible;
             StickyMines.Visibility         = Visibility.Collapsed;
             StickyTreasures.Visibility     = Visibility.Collapsed;
-            StickyRandomHires.Visibility   = Visibility.Collapsed;
+            StickyUnitRecruitment.Visibility = Visibility.Collapsed;
             StickyResourceBanks.Visibility = Visibility.Collapsed;
-            StickyStorageStructures.Visibility = Visibility.Collapsed;
+            StickyUtilityStructures.Visibility = Visibility.Collapsed;
+            StickyHeroImprovementStructures.Visibility = Visibility.Collapsed;
             active.Visibility              = Visibility.Visible;
         }
 

--- a/Olden Era - Template Editor/Services/ContentManagement/ContentItemGroup.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ContentItemGroup.cs
@@ -12,6 +12,18 @@ public static class ContentItemGroup
         ContentIds.MineGemstones,
         ContentIds.AlchemyLab
     };
+    /* ContentIds of storage structures - weekly reward for visiting */
+    public static readonly List<SidMapping> StorageStructures = new()
+    {
+        ContentIds.StorageWood,
+        ContentIds.StorageOre,
+        ContentIds.StorageGold,
+        ContentIds.StorageMercury,
+        ContentIds.StorageCrystals,
+        ContentIds.StorageGemstones,
+        ContentIds.StorageDust,
+        IncludeListIds.StorageBanks
+    };
     /* ContentIds of treasures */
     public static readonly List<SidMapping> Treasures = new() {
         ContentIds.MythicScrollBox,
@@ -21,7 +33,7 @@ public static class ContentItemGroup
         ContentIds.RandomItemLegendary
     };
     /* Random hire buildings matching the player faction */
-    public static readonly List<SidMapping> HireBuildings = new()
+    public static readonly List<SidMapping> HireStructures = new()
     {
         ContentIds.RandomHire1,
         ContentIds.RandomHire2,

--- a/Olden Era - Template Editor/Services/ContentManagement/ContentItemGroup.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ContentItemGroup.cs
@@ -7,14 +7,76 @@ public static class ContentItemGroup
         ContentIds.MineWood, 
         ContentIds.MineOre, 
         ContentIds.MineGold,
+        IncludeListIds.RandomRareMines,
+        IncludeListIds.RandomRareMinesBiomeRestricted,
         ContentIds.MineMercury,
         ContentIds.MineCrystals,
         ContentIds.MineGemstones,
-        ContentIds.AlchemyLab
+        ContentIds.AlchemyLab,
     };
-    /* ContentIds of storage structures - weekly reward for visiting */
-    public static readonly List<SidMapping> StorageStructures = new()
+    /* ContentIds of utility structures */
+    public static readonly List<SidMapping> UtilityStructures = new()
     {
+        ContentIds.Watchtower,
+        ContentIds.ManaWell,    
+        ContentIds.WindRose,
+        ContentIds.Market,
+        ContentIds.Tavern,
+        ContentIds.Forge,
+        ContentIds.Stables,
+        ContentIds.TearOfTruth,
+        ContentIds.Fountain,
+        ContentIds.Fountain2,
+        ContentIds.BeerFountain,
+        ContentIds.QuixsPath,
+        ContentIds.PileOfBooks,
+        ContentIds.MysteriousStone,
+        ContentIds.CrystalTrail,
+        ContentIds.SacrificialShrine,
+        ContentIds.Chimerologist,
+    };
+    /* ContentIds of treasures */
+    public static readonly List<SidMapping> Treasures = new() {
+        ContentIds.PandoraBox,
+        ContentIds.RandomItemCommon,
+        ContentIds.RandomItemRare,
+        ContentIds.RandomItemEpic,
+        ContentIds.RandomItemLegendary,
+        ContentIds.ScrollBox,
+        ContentIds.EnchantedScrollBox,
+        ContentIds.MythicScrollBox,
+        ContentIds.Prison,
+        ContentIds.Mirage
+    };
+    /* Unit recruitment buildings  */
+    public static readonly List<SidMapping> UnitRecruitment = new()
+    {
+        /* Random hires - matching the player faction */
+        IncludeListIds.RandomHiresLowTier,
+        ContentIds.RandomHire1,
+        ContentIds.RandomHire2,
+        ContentIds.RandomHire3,
+        ContentIds.RandomHire4,
+        IncludeListIds.RandomHiresHighTier,
+        ContentIds.RandomHire5,
+        ContentIds.RandomHire6,
+        ContentIds.RandomHire7,
+        IncludeListIds.RandomHiresAllTier,
+        ContentIds.MercenaryGuild,
+        /* Guarded unit banks */
+        IncludeListIds.RandomGuardedUnitBank,
+        ContentIds.JoustingRange,
+        ContentIds.UnforgottenGrave,
+        ContentIds.PetrifiedMemorial,
+        ContentIds.RitualPyre,
+        ContentIds.BorealCall,
+        ContentIds.TheGorge,
+        ContentIds.PointOfBalance
+    };
+    /* Resource banks */
+    public static readonly List<SidMapping> ResourceBanks = new()
+    {
+        IncludeListIds.BasicStorageBanks,
         ContentIds.StorageWood,
         ContentIds.StorageOre,
         ContentIds.StorageGold,
@@ -22,35 +84,76 @@ public static class ContentItemGroup
         ContentIds.StorageCrystals,
         ContentIds.StorageGemstones,
         ContentIds.StorageDust,
-        IncludeListIds.StorageBanks
-    };
-    /* ContentIds of treasures */
-    public static readonly List<SidMapping> Treasures = new() {
-        ContentIds.MythicScrollBox,
-        ContentIds.PandoraBox,
-        ContentIds.RandomItemCommon,
-        ContentIds.RandomItemEpic,
-        ContentIds.RandomItemLegendary
-    };
-    /* Random hire buildings matching the player faction */
-    public static readonly List<SidMapping> HireStructures = new()
-    {
-        ContentIds.RandomHire1,
-        ContentIds.RandomHire2,
-        ContentIds.RandomHire3,
-        ContentIds.RandomHire4,
-        ContentIds.RandomHire5,
-        ContentIds.RandomHire6,
-        ContentIds.RandomHire7,
-        IncludeListIds.RandomHiresLowTier,
-        IncludeListIds.RandomHiresHighTier,
-        IncludeListIds.RandomHiresAllTier
-    };
-    /* Resource banks */
-    public static readonly List<SidMapping> ResourceBanks = new()
-    {
         IncludeListIds.ResourceBanksTier1,
+        ContentIds.Gardener,
+        ContentIds.Windmill,
+        ContentIds.Village,
+        ContentIds.GingerbreadHouse,
+        ContentIds.PeasantCart,
+        ContentIds.AbandonedCorpse,
+        ContentIds.CrowNest,
+        ContentIds.GoblinCache,
         IncludeListIds.ResourceBanksTier2,
+        ContentIds.MontyHall,
+        ContentIds.HerosCrypt,
+        IncludeListIds.GuardedBanksTier1,
+        ContentIds.BlackTower,
+        ContentIds.AbandonedMansion,
+        ContentIds.MereasShrine,
+        ContentIds.ShadyDen,
+        IncludeListIds.GuardedBanksTier2,
+        ContentIds.RaidersCamp,
+        ContentIds.OvergrownGrave,
+        ContentIds.LegionsMemorial,
+        ContentIds.AlvarsEye,
+        ContentIds.CursedOldHouse,
+        ContentIds.AbnormalStructure,
+        ContentIds.PrismaticLair,
+        ContentIds.UncannyRite,
+        ContentIds.CircleOfLife,
+        ContentIds.IridescentAbbey,
+        IncludeListIds.GuardedBanksTier3,
+        ContentIds.TroglodyteThrone,
+        ContentIds.TwilightBloom,
+        ContentIds.UnstableRuins,
+        ContentIds.DragonUtopia,
+        ContentIds.ResearchLaboratory
+    };
+    /* Hero improvement structures */
+    public static readonly List<SidMapping> HeroImprovementStructures = new()
+    {
+        IncludeListIds.HeroStatsAndSkillsTier1,
+        ContentIds.StingingSword,
+        ContentIds.ArmoryAutomaton,
+        ContentIds.MagicWheel,
+        ContentIds.KnowledgeGarden,
+        ContentIds.WiseOwl,
+        IncludeListIds.HeroStatsAndSkillsTier2,
+        ContentIds.Fort,
+        ContentIds.OrbObservatory,
+        ContentIds.University,
+        ContentIds.Circus,
+        ContentIds.InfernalCirque,
+        IncludeListIds.HeroStatsAndSkillsTier3,
+        ContentIds.Maze,
+        ContentIds.TrialScales,
+        ContentIds.CollegeOfWonder,
+        ContentIds.LearningStone,
+        IncludeListIds.HeroExpTier2,
+        ContentIds.LostLibrary,
+        ContentIds.TreeOfKnowledge,
+        IncludeListIds.MagicBuildingsTier1,
+        ContentIds.MysticalTower,
+        ContentIds.CelestialSphere,
+        ContentIds.AltarOfMagic1,
+        ContentIds.AltarOfMagic2,
+        ContentIds.AltarOfMagic3,
+        ContentIds.AltarOfMagic4,
+        IncludeListIds.MagicBuildingsTier2,
+        ContentIds.MagicAmplifier1,
+        ContentIds.MagicAmplifier2,
+        ContentIds.MagicAmplifier3,
+        ContentIds.MagicAmplifier4,
     };
 }
 

--- a/Olden Era - Template Editor/Services/ContentManagement/ContentItemGroup.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ContentItemGroup.cs
@@ -62,6 +62,7 @@ public static class ContentItemGroup
         ContentIds.RandomHire6,
         ContentIds.RandomHire7,
         IncludeListIds.RandomHiresAllTier,
+        IncludeListIds.RandomHiresAllTierWeighted,
         ContentIds.MercenaryGuild,
         /* Guarded unit banks */
         IncludeListIds.RandomGuardedUnitBank,
@@ -122,6 +123,7 @@ public static class ContentItemGroup
     /* Hero improvement structures */
     public static readonly List<SidMapping> HeroImprovementStructures = new()
     {
+        IncludeListIds.HeroImprovementUncommon,
         IncludeListIds.HeroStatsAndSkillsTier1,
         ContentIds.StingingSword,
         ContentIds.ArmoryAutomaton,

--- a/Olden Era - Template Editor/Services/ContentManagement/ContentPresets.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ContentPresets.cs
@@ -3,6 +3,7 @@ using OldenEraTemplateEditor.Models;
 
 namespace OldenEraTemplateEditor.Services.ContentManagement
 {
+/* Some commonly found content items with rules, to use throughout the application. */
 public static class ContentPresets
 {
     /* Foothold rules derived from example templates. Might need adjustment. */
@@ -31,64 +32,6 @@ public static class ContentPresets
             .AddRules(rules)
             .Build();
     }
-    
-    /* Basic wood mine, guarded & anchored near the player castle */
-    public static ContentItem MineWood_Anchored() => 
-        ContentItemBuilder.Create(ContentIds.MineWood.Sid)
-            .WithName("name_mine_wood")
-            .Mine()
-            .Guarded()
-            .AddRules([
-                RulePresets.NearCastle(),
-                RulePresets.CrossroadsDistance(DistancePresets.Near)
-            ])
-            .Build();
-    /* Basic ore mine, guarded & anchored near the player castle */
-    public static ContentItem MineOre_Anchored() => 
-        ContentItemBuilder.Create(ContentIds.MineOre.Sid)
-            .WithName("name_mine_ore")
-            .Mine()
-            .Guarded()
-            .AddRules([
-                RulePresets.NearCastle(),
-                RulePresets.CrossroadsDistance(DistancePresets.Near)
-            ])
-            .Build();
-    /* Gold mine near crossroads */
-    public static ContentItem MineGold_NearCrossroads() => 
-        ContentItemBuilder.Create(ContentIds.MineGold.Sid)
-            .Mine()
-            .AddRules([
-                RulePresets.CrossroadsDistance(DistancePresets.Near)
-            ])
-            .Build();
-    
-    /* Mines near roads */
-    public static ContentItem MineCrystals_NextToRoad() =>
-        ContentItemBuilder.Create(ContentIds.MineCrystals.Sid)
-            .WithName("name_mine_crystals")
-            .Mine()
-            .RoadDistance(DistancePresets.NextTo)
-            .Build();
-    public static ContentItem MineMercury_NextToRoad() =>
-        ContentItemBuilder.Create(ContentIds.MineMercury.Sid)
-            .WithName("name_mine_mercury")
-            .Mine()
-            .RoadDistance(DistancePresets.NextTo)
-            .Build();
-    public static ContentItem MineGemstones_NextToRoad() =>
-        ContentItemBuilder.Create(ContentIds.MineGemstones.Sid)
-            .WithName("name_mine_gemstones")
-            .Mine()
-            .RoadDistance(DistancePresets.NextTo)
-            .Build();
-    public static ContentItem AlchemyLab_NearRoad() =>
-        ContentItemBuilder.Create(ContentIds.AlchemyLab.Sid)
-            .WithName("name_alchemy_lab")
-            .Mine()
-            .RoadDistance(DistancePresets.Near)
-            .Build();
-
 }
 
 }

--- a/Olden Era - Template Editor/Services/ContentManagement/SidMapping.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/SidMapping.cs
@@ -83,7 +83,7 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping Stables = new() { Sid = "stables", Name = "Stables" };
         public static readonly SidMapping Tavern = new() { Sid = "tavern", Name = "Tavern" };
         public static readonly SidMapping TearOfTruth = new() { Sid = "tear_of_truth", Name = "Tear Of Truth" };
-        public static readonly SidMapping TheGorge = new() { Sid = "the_gorge", Name = "The Gorge" };
+        public static readonly SidMapping TheGorge = new() { Sid = "the_gorge", Name = "Carrion Pile" }; // Mismatch from SID, but that's the name shown in-game.
         public static readonly SidMapping TownGate = new() { Sid = "town_gate", Name = "Town Gate" };
         public static readonly SidMapping TreeOfAbundance = new() { Sid = "tree_of_abundance", Name = "Tree Of Abundance" };
         public static readonly SidMapping TroglodyteThrone = new() { Sid = "troglodyte_throne", Name = "Troglodyte Throne" };

--- a/Olden Era - Template Editor/Services/ContentManagement/SidMapping.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/SidMapping.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -19,14 +20,14 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping BeerFountain = new() { Sid = "beer_fountain", Name = "Beer Fountain" };
         public static readonly SidMapping BorealCall = new() { Sid = "boreal_call", Name = "Boreal Call" };
         public static readonly SidMapping CelestialSphere = new() { Sid = "celestial_sphere", Name = "Celestial Sphere" };
-        public static readonly SidMapping AltarOfMagic1 = new() { Sid = "altar_of_magic_1", Name = "Altar Of Magic 1" };
-        public static readonly SidMapping AltarOfMagic2 = new() { Sid = "altar_of_magic_2", Name = "Altar Of Magic 2" };
-        public static readonly SidMapping AltarOfMagic3 = new() { Sid = "altar_of_magic_3", Name = "Altar Of Magic 3" };
-        public static readonly SidMapping AltarOfMagic4 = new() { Sid = "altar_of_magic_4", Name = "Altar Of Magic 4" };
-        public static readonly SidMapping MagicAmplifier1 = new() { Sid = "magic_amplifier_1", Name = "Magic Amplifier 1" };
-        public static readonly SidMapping MagicAmplifier2 = new() { Sid = "magic_amplifier_2", Name = "Magic Amplifier 2" };
-        public static readonly SidMapping MagicAmplifier3 = new() { Sid = "magic_amplifier_3", Name = "Magic Amplifier 3" };
-        public static readonly SidMapping MagicAmplifier4 = new() { Sid = "magic_amplifier_4", Name = "Magic Amplifier 4" };
+        public static readonly SidMapping AltarOfMagic1 = new() { Sid = "altar_of_magic_1", Name = "Nightshade Shrine" };
+        public static readonly SidMapping AltarOfMagic2 = new() { Sid = "altar_of_magic_2", Name = "Daylight Shrine" };
+        public static readonly SidMapping AltarOfMagic3 = new() { Sid = "altar_of_magic_3", Name = "Arcane Shrine" };
+        public static readonly SidMapping AltarOfMagic4 = new() { Sid = "altar_of_magic_4", Name = "Primal Shrine" };
+        public static readonly SidMapping MagicAmplifier1 = new() { Sid = "magic_amplifier_1", Name = "Nightshade Amplifier" };
+        public static readonly SidMapping MagicAmplifier2 = new() { Sid = "magic_amplifier_2", Name = "Daylight Amplifier" };
+        public static readonly SidMapping MagicAmplifier3 = new() { Sid = "magic_amplifier_3", Name = "Arcane Amplifier" };
+        public static readonly SidMapping MagicAmplifier4 = new() { Sid = "magic_amplifier_4", Name = "Primal Amplifier" };
         public static readonly SidMapping Chimerologist = new() { Sid = "chimerologist", Name = "Chimerologist" };
         public static readonly SidMapping Circus = new() { Sid = "circus", Name = "Circus" };
         public static readonly SidMapping CollegeOfWonder = new() { Sid = "college_of_wonder", Name = "College Of Wonder" };
@@ -146,6 +147,7 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping RandomHiresLowTier = new() { Sid = "content_list_building_random_hires_low_tier", Name = "Random Hires Low Tier" };
         public static readonly SidMapping RandomHiresHighTier = new() { Sid = "content_list_building_random_hires_high_tier", Name = "Random Hires High Tier" };
         public static readonly SidMapping RandomHiresAllTier = new() { Sid = "basic_content_list_building_random_hires", Name = "Random Hires Any Tier" };
+        public static readonly SidMapping RandomHiresAllTierWeighted = new() { Sid = "content_list_building_random_hires", Name = "Random Hires Any Tier (Weighted)" };
         public static readonly SidMapping ResourceBanksTier1 = new() { Sid = "basic_content_list_building_guarded_resource_banks_tier_1", Name = "Resource Banks T1" };
         public static readonly SidMapping ResourceBanksTier2 = new() { Sid = "basic_content_list_building_guarded_resource_banks_tier_2", Name = "Resource Banks T2" };
         public static readonly SidMapping GuardedBanksTier1 = new() { Sid = "basic_content_list_building_guarded_resource_banks_tier_1", Name = "Guarded Banks T1" };
@@ -163,10 +165,7 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping HeroStatsAndSkillsTier3 = new() { Sid = "basic_content_list_building_hero_stats_and_skills_tier_3", Name = "Random Hero Stat/Skill Tier 3" };
         public static readonly SidMapping MagicBuildingsTier1 = new() { Sid = "basic_content_list_building_magic_tier_1", Name = "Random Magic Building Tier 1" };
         public static readonly SidMapping MagicBuildingsTier2 = new() { Sid = "basic_content_list_building_magic_tier_2", Name = "Random Magic Building Tier 2" };
-
-
-        
-        
+        public static readonly SidMapping HeroImprovementUncommon = new() { Sid = "content_list_building_uncommon_hero_banks", Name = "Uncommon Hero Improvement" };
     }
 
     public static class GlobalContent

--- a/Olden Era - Template Editor/Services/ContentManagement/SidMapping.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/SidMapping.cs
@@ -19,6 +19,14 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping BeerFountain = new() { Sid = "beer_fountain", Name = "Beer Fountain" };
         public static readonly SidMapping BorealCall = new() { Sid = "boreal_call", Name = "Boreal Call" };
         public static readonly SidMapping CelestialSphere = new() { Sid = "celestial_sphere", Name = "Celestial Sphere" };
+        public static readonly SidMapping AltarOfMagic1 = new() { Sid = "altar_of_magic_1", Name = "Altar Of Magic 1" };
+        public static readonly SidMapping AltarOfMagic2 = new() { Sid = "altar_of_magic_2", Name = "Altar Of Magic 2" };
+        public static readonly SidMapping AltarOfMagic3 = new() { Sid = "altar_of_magic_3", Name = "Altar Of Magic 3" };
+        public static readonly SidMapping AltarOfMagic4 = new() { Sid = "altar_of_magic_4", Name = "Altar Of Magic 4" };
+        public static readonly SidMapping MagicAmplifier1 = new() { Sid = "magic_amplifier_1", Name = "Magic Amplifier 1" };
+        public static readonly SidMapping MagicAmplifier2 = new() { Sid = "magic_amplifier_2", Name = "Magic Amplifier 2" };
+        public static readonly SidMapping MagicAmplifier3 = new() { Sid = "magic_amplifier_3", Name = "Magic Amplifier 3" };
+        public static readonly SidMapping MagicAmplifier4 = new() { Sid = "magic_amplifier_4", Name = "Magic Amplifier 4" };
         public static readonly SidMapping Chimerologist = new() { Sid = "chimerologist", Name = "Chimerologist" };
         public static readonly SidMapping Circus = new() { Sid = "circus", Name = "Circus" };
         public static readonly SidMapping CollegeOfWonder = new() { Sid = "college_of_wonder", Name = "College Of Wonder" };
@@ -44,10 +52,11 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping MineOre = new() { Sid = "mine_ore", Name = "Ore Mine" };
         public static readonly SidMapping MineWood = new() { Sid = "mine_wood", Name = "Sawmill" };
         public static readonly SidMapping Mirage = new() { Sid = "mirage", Name = "Mirage" };
-        public static readonly SidMapping MontyHall = new() { Sid = "monty_hall", Name = "Monty Hall" };
         public static readonly SidMapping MysteriousStone = new() { Sid = "mysterious_stone", Name = "Mysterious Stone" };
         public static readonly SidMapping MysticalTower = new() { Sid = "mystical_tower", Name = "Mystical Tower" };
-        public static readonly SidMapping MythicScrollBox = new() { Sid = "mythic_scroll_box", Name = "Mythic Scroll Box" };
+        public static readonly SidMapping ScrollBox = new() { Sid = "scroll_box", Name = "Magic Scroll" };
+        public static readonly SidMapping EnchantedScrollBox = new() { Sid = "enchanted_scroll_box", Name = "Enchanted Scroll" };
+        public static readonly SidMapping MythicScrollBox = new() { Sid = "mythic_scroll_box", Name = "Mythic Scroll" };
         public static readonly SidMapping OrbObservatory = new() { Sid = "orb_observatory", Name = "Orb Observatory" };
         public static readonly SidMapping PandoraBox = new() { Sid = "pandora_box", Name = "Pandora Box" };
         public static readonly SidMapping PetrifiedMemorial = new() { Sid = "petrified_memorial", Name = "Petrified Memorial" };
@@ -55,13 +64,13 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping PointOfBalance = new() { Sid = "point_of_balance", Name = "Point Of Balance" };
         public static readonly SidMapping Prison = new() { Sid = "prison", Name = "Prison" };
         public static readonly SidMapping QuixsPath = new() { Sid = "quixs_path", Name = "Quix's Path" };
-        public static readonly SidMapping RandomHire1 = new() { Sid = "random_hire_1", Name = "Random Hire 1" };
-        public static readonly SidMapping RandomHire2 = new() { Sid = "random_hire_2", Name = "Random Hire 2" };
-        public static readonly SidMapping RandomHire3 = new() { Sid = "random_hire_3", Name = "Random Hire 3" };
-        public static readonly SidMapping RandomHire4 = new() { Sid = "random_hire_4", Name = "Random Hire 4" };
-        public static readonly SidMapping RandomHire5 = new() { Sid = "random_hire_5", Name = "Random Hire 5" };
-        public static readonly SidMapping RandomHire6 = new() { Sid = "random_hire_6", Name = "Random Hire 6" };
-        public static readonly SidMapping RandomHire7 = new() { Sid = "random_hire_7", Name = "Random Hire 7" };
+        public static readonly SidMapping RandomHire1 = new() { Sid = "random_hire_1", Name = "Random Hire Tier 1" };
+        public static readonly SidMapping RandomHire2 = new() { Sid = "random_hire_2", Name = "Random Hire Tier 2" };
+        public static readonly SidMapping RandomHire3 = new() { Sid = "random_hire_3", Name = "Random Hire Tier 3" };
+        public static readonly SidMapping RandomHire4 = new() { Sid = "random_hire_4", Name = "Random Hire Tier 4" };
+        public static readonly SidMapping RandomHire5 = new() { Sid = "random_hire_5", Name = "Random Hire Tier 5" };
+        public static readonly SidMapping RandomHire6 = new() { Sid = "random_hire_6", Name = "Random Hire Tier 6" };
+        public static readonly SidMapping RandomHire7 = new() { Sid = "random_hire_7", Name = "Random Hire Tier 7" };
         public static readonly SidMapping RandomItemCommon = new() { Sid = "random_item_common", Name = "Random Item Common" };
         public static readonly SidMapping RandomItemEpic = new() { Sid = "random_item_epic", Name = "Random Item Epic" };
         public static readonly SidMapping RandomItemLegendary = new() { Sid = "random_item_legendary", Name = "Random Item Legendary" };
@@ -78,6 +87,7 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping TownGate = new() { Sid = "town_gate", Name = "Town Gate" };
         public static readonly SidMapping TreeOfAbundance = new() { Sid = "tree_of_abundance", Name = "Tree Of Abundance" };
         public static readonly SidMapping TroglodyteThrone = new() { Sid = "troglodyte_throne", Name = "Troglodyte Throne" };
+        public static readonly SidMapping TwilightBloom = new() { Sid = "twilight_bloom", Name = "Twilight Bloom" };
         public static readonly SidMapping UnforgottenGrave = new() { Sid = "unforgotten_grave", Name = "Unforgotten Grave" };
         public static readonly SidMapping University = new() { Sid = "university", Name = "University" };
         public static readonly SidMapping UnstableRuins = new() { Sid = "unstable_ruins", Name = "Unstable Ruins" };
@@ -91,6 +101,40 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping StorageCrystals = new() { Sid = "storage_crystals", Name = "Crystals Storage" };
         public static readonly SidMapping StorageGemstones = new() { Sid = "storage_gemstones", Name = "Gemstones Storage" };
         public static readonly SidMapping StorageDust = new() { Sid = "storage_dust", Name = "Dust Storage" };
+        public static readonly SidMapping Gardener = new() { Sid = "gardener", Name = "Gardener" };
+        public static readonly SidMapping Windmill = new() { Sid = "windmill", Name = "Windmill" };
+        public static readonly SidMapping Village = new() { Sid = "village", Name = "Village" };
+        public static readonly SidMapping GingerbreadHouse = new() { Sid = "gingerbread_house", Name = "Gingerbread House" };
+        public static readonly SidMapping PeasantCart = new() { Sid = "peasant_cart", Name = "Peasant Cart" };
+        public static readonly SidMapping AbandonedCorpse = new() { Sid = "abandoned_corpse", Name = "Abandoned Corpse" };
+        public static readonly SidMapping AbandonedMansion = new() { Sid = "abandoned_mansion", Name = "Abandoned Mansion" };
+        public static readonly SidMapping AbnormalStructure = new() { Sid = "abnormal_structure", Name = "Abnormal Structure" };
+        public static readonly SidMapping AlvarsEye = new() { Sid = "alvars_eye", Name = "Alvar's Eye" };
+        public static readonly SidMapping BlackTower = new() { Sid = "black_tower", Name = "Black Tower" };
+        public static readonly SidMapping CircleOfLife = new() { Sid = "circle_of_life", Name = "Circle Of Life" };
+        public static readonly SidMapping CursedOldHouse = new() { Sid = "cursed_old_house", Name = "Cursed Old House" };
+        public static readonly SidMapping CrowNest = new() { Sid = "crow_nest", Name = "Crow Nest" };
+        public static readonly SidMapping GoblinCache = new() { Sid = "goblin_cache", Name = "Goblin Cache" };
+        public static readonly SidMapping IridescentAbbey = new() { Sid = "iridescent_abbey", Name = "Iridescent Abbey" };
+        public static readonly SidMapping LegionsMemorial = new() { Sid = "legions_memorial", Name = "Legions Memorial" };
+        public static readonly SidMapping MereasShrine = new() { Sid = "mereas_shrine", Name = "Merea's Shrine" };
+        public static readonly SidMapping MontyHall = new() { Sid = "monty_hall", Name = "Monty Hall" };
+        public static readonly SidMapping OvergrownGrave = new() { Sid = "overgrown_grave", Name = "Overgrown Grave" };
+        public static readonly SidMapping PrismaticLair = new() { Sid = "prismatic_lair", Name = "Prismatic Lair" };
+        public static readonly SidMapping RaidersCamp = new() { Sid = "raiders_camp", Name = "Raiders Camp" };
+        public static readonly SidMapping HerosCrypt = new() { Sid = "heros_crypt", Name = "Hero's Crypt" };
+        public static readonly SidMapping UncannyRite = new() { Sid = "uncanny_rite", Name = "Uncanny Rite" };
+        public static readonly SidMapping LearningStone = new() { Sid = "learning_stone", Name = "Learning Stone" };
+        public static readonly SidMapping LostLibrary = new() { Sid = "lost_library", Name = "Lost Library" };
+        public static readonly SidMapping TreeOfKnowledge = new() { Sid = "tree_of_knowledge", Name = "Tree Of Knowledge" };
+        public static readonly SidMapping StingingSword = new() { Sid = "stinging_sword", Name = "Stinging Sword" };
+        public static readonly SidMapping ArmoryAutomaton = new() { Sid = "armory_automaton", Name = "Armory Automaton" };
+        public static readonly SidMapping MagicWheel = new() { Sid = "magic_wheel", Name = "Magic Wheel" };
+        public static readonly SidMapping KnowledgeGarden = new() { Sid = "knowledge_garden", Name = "Knowledge Garden" };
+        public static readonly SidMapping Maze = new() { Sid = "maze", Name = "Maze" };
+        public static readonly SidMapping TrialScales = new() { Sid = "trial_scales", Name = "Trial Scales" };
+        public static readonly SidMapping MercenaryGuild = new() { Sid = "mercenary_guild", Name = "Mercenary Guild" };
+        
     }
 
     public static class IncludeListIds
@@ -101,10 +145,28 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
 
         public static readonly SidMapping RandomHiresLowTier = new() { Sid = "content_list_building_random_hires_low_tier", Name = "Random Hires Low Tier" };
         public static readonly SidMapping RandomHiresHighTier = new() { Sid = "content_list_building_random_hires_high_tier", Name = "Random Hires High Tier" };
-        public static readonly SidMapping RandomHiresAllTier = new() { Sid = "basic_content_list_building_random_hires", Name = "Random Hires All Tier" };
+        public static readonly SidMapping RandomHiresAllTier = new() { Sid = "basic_content_list_building_random_hires", Name = "Random Hires Any Tier" };
         public static readonly SidMapping ResourceBanksTier1 = new() { Sid = "basic_content_list_building_guarded_resource_banks_tier_1", Name = "Resource Banks T1" };
         public static readonly SidMapping ResourceBanksTier2 = new() { Sid = "basic_content_list_building_guarded_resource_banks_tier_2", Name = "Resource Banks T2" };
-        public static readonly SidMapping StorageBanks = new() { Sid = "basic_content_list_basic_storage", Name = "Random Basic Storage" };
+        public static readonly SidMapping GuardedBanksTier1 = new() { Sid = "basic_content_list_building_guarded_resource_banks_tier_1", Name = "Guarded Banks T1" };
+        public static readonly SidMapping GuardedBanksTier2 = new() { Sid = "basic_content_list_building_guarded_resource_banks_tier_2", Name = "Guarded Banks T2" };
+        public static readonly SidMapping GuardedBanksTier3 = new() { Sid = "basic_content_list_building_guarded_resource_banks_tier_3", Name = "Guarded Banks T3" };
+        public static readonly SidMapping BasicStorageBanks = new() { Sid = "basic_content_list_basic_storage", Name = "Random Basic Storage" };
+
+        public static readonly SidMapping RandomRareMines = new() { Sid = "basic_content_list_rare_mines", Name = "Random Rare Mine" };
+        public static readonly SidMapping RandomRareMinesBiomeRestricted = new() { Sid = "basic_content_list_rare_mines_by_biome", Name = "Random Rare Mine (Biome Restricted)" };
+        public static readonly SidMapping RandomGuardedUnitBank = new() { Sid = "basic_content_list_building_guarded_units_banks", Name = "Random Guarded Unit Bank" };
+        public static readonly SidMapping HeroBuffTier1 = new() { Sid = "basic_content_list_building_hero_buff_tier_1", Name = "Random Hero Buff Tier 1" };
+        public static readonly SidMapping HeroExpTier2 = new() { Sid = "basic_content_list_building_hero_exp_tier_2", Name = "Random Hero Exp Tier 2" };
+        public static readonly SidMapping HeroStatsAndSkillsTier1 = new() { Sid = "basic_content_list_building_hero_stats_and_skills_tier_1", Name = "Random Hero Stat/Skill Tier 1" };
+        public static readonly SidMapping HeroStatsAndSkillsTier2 = new() { Sid = "basic_content_list_building_hero_stats_and_skills_tier_2", Name = "Random Hero Stat/Skill Tier 2" };
+        public static readonly SidMapping HeroStatsAndSkillsTier3 = new() { Sid = "basic_content_list_building_hero_stats_and_skills_tier_3", Name = "Random Hero Stat/Skill Tier 3" };
+        public static readonly SidMapping MagicBuildingsTier1 = new() { Sid = "basic_content_list_building_magic_tier_1", Name = "Random Magic Building Tier 1" };
+        public static readonly SidMapping MagicBuildingsTier2 = new() { Sid = "basic_content_list_building_magic_tier_2", Name = "Random Magic Building Tier 2" };
+
+
+        
+        
     }
 
     public static class GlobalContent

--- a/Olden Era - Template Editor/Services/ContentManagement/SidMapping.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/SidMapping.cs
@@ -37,12 +37,12 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping JoustingRange = new() { Sid = "jousting_range", Name = "Jousting Range" };
         public static readonly SidMapping ManaWell = new() { Sid = "mana_well", Name = "Mana Well" };
         public static readonly SidMapping Market = new() { Sid = "market", Name = "Market" };
-        public static readonly SidMapping MineCrystals = new() { Sid = "mine_crystals", Name = "Mine Crystals" };
-        public static readonly SidMapping MineGemstones = new() { Sid = "mine_gemstones", Name = "Mine Gemstones" };
-        public static readonly SidMapping MineGold = new() { Sid = "mine_gold", Name = "Mine Gold" };
-        public static readonly SidMapping MineMercury = new() { Sid = "mine_mercury", Name = "Mine Mercury" };
-        public static readonly SidMapping MineOre = new() { Sid = "mine_ore", Name = "Mine Ore" };
-        public static readonly SidMapping MineWood = new() { Sid = "mine_wood", Name = "Mine Wood" };
+        public static readonly SidMapping MineCrystals = new() { Sid = "mine_crystals", Name = "Crystal Vein" };
+        public static readonly SidMapping MineGemstones = new() { Sid = "mine_gemstones", Name = "Gem Mound" };
+        public static readonly SidMapping MineGold = new() { Sid = "mine_gold", Name = "Gold Mine" };
+        public static readonly SidMapping MineMercury = new() { Sid = "mine_mercury", Name = "Mercury Fissure" };
+        public static readonly SidMapping MineOre = new() { Sid = "mine_ore", Name = "Ore Mine" };
+        public static readonly SidMapping MineWood = new() { Sid = "mine_wood", Name = "Sawmill" };
         public static readonly SidMapping Mirage = new() { Sid = "mirage", Name = "Mirage" };
         public static readonly SidMapping MontyHall = new() { Sid = "monty_hall", Name = "Monty Hall" };
         public static readonly SidMapping MysteriousStone = new() { Sid = "mysterious_stone", Name = "Mysterious Stone" };
@@ -84,10 +84,19 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping Watchtower = new() { Sid = "watchtower", Name = "Watchtower" };
         public static readonly SidMapping WindRose = new() { Sid = "wind_rose", Name = "Wind Rose" };
         public static readonly SidMapping WiseOwl = new() { Sid = "wise_owl", Name = "Wise Owl" };
+        public static readonly SidMapping StorageWood = new() { Sid = "storage_wood", Name = "Wood Storage" };
+        public static readonly SidMapping StorageOre = new() { Sid = "storage_ore", Name = "Ore Storage" };
+        public static readonly SidMapping StorageGold = new() { Sid = "storage_gold", Name = "Gold Storage" };
+        public static readonly SidMapping StorageMercury = new() { Sid = "storage_mercury", Name = "Mercury Storage" };
+        public static readonly SidMapping StorageCrystals = new() { Sid = "storage_crystals", Name = "Crystals Storage" };
+        public static readonly SidMapping StorageGemstones = new() { Sid = "storage_gemstones", Name = "Gemstones Storage" };
+        public static readonly SidMapping StorageDust = new() { Sid = "storage_dust", Name = "Dust Storage" };
     }
 
     public static class IncludeListIds
     {
+        /* string identifier for include lists, to properly handle content item creation. (These are not real SID values of content items, but names of their include lists) */
+        public static readonly string Identifier = "content";
         public static IReadOnlyList<SidMapping> GetAll() => SidReflection.GetSidMappings(typeof(IncludeListIds));
 
         public static readonly SidMapping RandomHiresLowTier = new() { Sid = "content_list_building_random_hires_low_tier", Name = "Random Hires Low Tier" };
@@ -95,6 +104,7 @@ namespace OldenEraTemplateEditor.Services.ContentManagement
         public static readonly SidMapping RandomHiresAllTier = new() { Sid = "basic_content_list_building_random_hires", Name = "Random Hires All Tier" };
         public static readonly SidMapping ResourceBanksTier1 = new() { Sid = "basic_content_list_building_guarded_resource_banks_tier_1", Name = "Resource Banks T1" };
         public static readonly SidMapping ResourceBanksTier2 = new() { Sid = "basic_content_list_building_guarded_resource_banks_tier_2", Name = "Resource Banks T2" };
+        public static readonly SidMapping StorageBanks = new() { Sid = "basic_content_list_basic_storage", Name = "Random Basic Storage" };
     }
 
     public static class GlobalContent

--- a/Olden Era - Template Editor/Services/ContentManagement/ZoneContent.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ZoneContent.cs
@@ -9,19 +9,20 @@ public class ZoneMandatoryContent
 {
         public readonly ObservableCollection<ZoneContentItemUI> mines = new();
         public readonly ObservableCollection<ZoneContentItemUI> treasures = new();
-        public readonly ObservableCollection<ZoneContentItemUI> randomHires = new();
+        public readonly ObservableCollection<ZoneContentItemUI> unitRecruitment = new();
         public readonly ObservableCollection<ZoneContentItemUI> resourceBanks = new();
-    public readonly ObservableCollection<ZoneContentItemUI> storageStructures = new();
-
+        public readonly ObservableCollection<ZoneContentItemUI> utilityStructures = new();
+        public readonly ObservableCollection<ZoneContentItemUI> heroImprovementStructures = new();
         private IEnumerable<ObservableCollection<ZoneContentItemUI>> Collections
         {
             get
             {
                 yield return mines;
                 yield return treasures;
-                yield return randomHires;
+                yield return unitRecruitment;
                 yield return resourceBanks;
-                yield return storageStructures;
+                yield return utilityStructures;
+                yield return heroImprovementStructures;
             }
         }
 

--- a/Olden Era - Template Editor/Services/ContentManagement/ZoneContent.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ZoneContent.cs
@@ -1,0 +1,45 @@
+using System.Collections.ObjectModel;
+using Olden_Era___Template_Editor.Models;
+using OldenEraTemplateEditor.Models;
+
+namespace OldenEraTemplateEditor.Services.ContentManagement
+{
+
+public class ZoneMandatoryContent
+{
+        public readonly ObservableCollection<ZoneContentItemUI> mines = new();
+        public readonly ObservableCollection<ZoneContentItemUI> treasures = new();
+        public readonly ObservableCollection<ZoneContentItemUI> randomHires = new();
+        public readonly ObservableCollection<ZoneContentItemUI> resourceBanks = new();
+    public readonly ObservableCollection<ZoneContentItemUI> storageStructures = new();
+
+        private IEnumerable<ObservableCollection<ZoneContentItemUI>> Collections
+        {
+            get
+            {
+                yield return mines;
+                yield return treasures;
+                yield return randomHires;
+                yield return resourceBanks;
+                yield return storageStructures;
+            }
+        }
+
+        public IEnumerable<ZoneContentItemUI> AllItems => Collections.SelectMany(collection => collection);
+
+        /* Removes the specified item from any of the collections. Returns true if the item was found and removed, false otherwise. */
+        public bool Remove(ZoneContentItemUI item)
+        {
+            return Collections.Any(collection => collection.Remove(item));
+        }
+
+        public void Clear()
+        {
+            foreach (var collection in Collections)
+            {
+                collection.Clear();
+            }
+        }
+}
+
+}

--- a/Olden Era - Template Editor/Services/ContentManagement/ZoneContentManager.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ZoneContentManager.cs
@@ -26,15 +26,7 @@ public static class ZoneContentManager
         content.AddRange([
             // DEBUG HELPER: Unguarded full map reveal near starting castle.
             //ContentItemBuilder.Create(ContentIds.WindRose.Sid).RoadDistance(DistancePresets.NextTo).AddRule(RulePresets.NearCastle()).Guarded(false).Build(),
-            
-            // ── Utility buildings (Blitz/Kerberos/Exodus pattern). ──
-            new() { Sid = "watchtower" },
-            ContentItemBuilder.Create(ContentIds.Market.Sid).Guarded().RoadDistance(DistancePresets.Near).Build(),
-            ContentItemBuilder.Create(ContentIds.ManaWell.Sid).RoadDistance(DistancePresets.Near).Build(),
-            // ── Hero training — tier-2 stat building (fort/university/orb_observatory) ──
-            //    + uncommon hero bank (university/wise_owl/tree_of_knowledge) (Blitz/Exodus pattern).
-            new() { IncludeLists = ["basic_content_list_building_hero_stats_and_skills_tier_2"] },
-            new() { IncludeLists = ["content_list_building_uncommon_hero_banks"] },
+            // TODO: Add support for customizing pandora box contents (different variants)
             new() { IncludeLists = ["content_list_pickup_pandora_box_army_low_tier"], IsGuarded = true },
         ]);
         return content;

--- a/Olden Era - Template Editor/Services/ContentManagement/ZoneContentManager.cs
+++ b/Olden Era - Template Editor/Services/ContentManagement/ZoneContentManager.cs
@@ -96,10 +96,10 @@ public static class ZoneContentManager
 
         content.AddRange([
             // Mines — full rare set + gold + alchemy lab (Yin Yang/Staircase t3 pattern).
-            ContentPresets.MineCrystals_NextToRoad(),
-            ContentPresets.MineMercury_NextToRoad(),
-            ContentPresets.MineGemstones_NextToRoad(),
-            ContentPresets.AlchemyLab_NearRoad(),
+            ContentItemBuilder.Create(ContentIds.MineCrystals.Sid).WithName("name_mine_crystals").Mine().RoadDistance(DistancePresets.NextTo).Build(),
+            ContentItemBuilder.Create(ContentIds.MineMercury.Sid).WithName("name_mine_mercury").Mine().RoadDistance(DistancePresets.NextTo).Build(),
+            ContentItemBuilder.Create(ContentIds.MineGemstones.Sid).WithName("name_mine_gemstones").Mine().RoadDistance(DistancePresets.NextTo).Build(),
+            ContentItemBuilder.Create(ContentIds.AlchemyLab.Sid).WithName("name_alchemy_lab").Mine().RoadDistance(DistancePresets.NextTo).Build(),
             ContentItemBuilder.Create(ContentIds.MineGold.Sid).Mine().RoadDistance(DistancePresets.Near).Build(),
             // Utility — watchtower (guarded) + vision building (tier 1 only: flattering_mirror/watchtower).
             // wind_rose (full map reveal) lives in tier_2 and belongs exclusively in high zones.
@@ -185,7 +185,7 @@ public static class ZoneContentManager
             new() { IncludeLists = ["content_list_pickup_pandora_box_army_high_tier"] },
             new() { IncludeLists = ["content_list_pickup_pandora_box_army_high_tier"] },
             // Mines — gold-heavy with full rare set.
-            ContentPresets.MineGold_NearCrossroads(),
+            ContentItemBuilder.Create(ContentIds.MineGold.Sid).Mine().AddRule(RulePresets.CrossroadsDistance(DistancePresets.Near)).Build(),
             ContentItemBuilder.Create(ContentIds.MineGold.Sid).Mine().Build(),
             ContentItemBuilder.Create(ContentIds.MineGold.Sid).Mine().Build(),
             ContentItemBuilder.Create(ContentIds.MineCrystals.Sid).Mine().Build(),


### PR DESCRIPTION
Extension of recently added player zone customization.
- Added more content groups to the UI. Should cover most of available entities.
- Rearranged random groups to indicate what is in the pool.
- Name fixes for items that differ between in-game visible name and their SID, at least these that I found out about
- Code cleanup, removed some redundancy and grouped it better logically.

I'll be doing further testing if everything works fine, but that's a lot of items. So far tested on many maps and didn't find an issue yet.

Customizable content now includes:
- Mines, random mines, and mines restricted by biome
- Utility structures (Watchtowers, Stables, Temporary buffs, Fountains etc.)
- More tresures (All rarity of items, magic scrolls, grail)
- Unit recruitment - not only random hires, but also guarded unit banks & mercenary guild
- All available resource banks, also the ones that require fight with the guard.
- Hero improvement structures - attributes, experience, magic, and random content pools.